### PR TITLE
Fixing issue where pane manager would delete rules made by users

### DIFF
--- a/src/raw/Modules/Panes.js
+++ b/src/raw/Modules/Panes.js
@@ -5069,7 +5069,6 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
             }
 
             var movedSelector = getSelector(entry, EVUI.Modules.Panes.Constants.CSS_Moved);
-            _settings.stylesheetManager.removeRules(_settings.cssSheetName, movedSelector);
 
             var rules =
             {
@@ -5203,9 +5202,6 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
                     }
                 }
             }          
-
-
-            _settings.stylesheetManager.removeRules(_settings.cssSheetName, resizedSelector);
 
             var rules = {};
 


### PR DESCRIPTION
When the pane manager is moving or resizing a pane, it adds classes to change the position and size of the pane and was deleting those selectors from the stylesheet instead of removing the specific rules, which removed any additional user styling added to those selectors. They now just reset their values instead of removing the selectors entirely.