### PR TITLE
Pane disambiguation 

### DIFF
--- a/test/EventUITest/Pages/Scratchpad/Window/ShowFromMarkup.cshtml
+++ b/test/EventUITest/Pages/Scratchpad/Window/ShowFromMarkup.cshtml
@@ -3,5 +3,11 @@
 @{
 }
 
-<button evui-pane-id="http" evui-pane-src="/Partials/Pane/Http.html" evui-pane-show-settings='absolutePosition.top: 500; showTransition.css:{"display": "block", "backgroundColor": "blue"}; showTransition.duration:3000; absolutePosition.left: 500;' onclick="$evui.showPane(event)">Via HTTP</button>
+<button evui-pane-src="/Partials/Pane/Http.html" evui-pane-show-settings='absolutePosition.top: 500; showTransition.css:{"display": "block", "backgroundColor": "blue"}; showTransition.duration:3000; absolutePosition.left: 500;' onclick="$evui.showPane(event)">Via HTTP</button>
+<button evui-pane-src="/Partials/Pane/Http.html" evui-pane-show-settings='absolutePosition.top: 500; showTransition.css:{"display": "block", "backgroundColor": "blue"}; showTransition.duration:3000; absolutePosition.left: 500;' onclick="$evui.showPane(event)">Via HTTP2</button>
 <button evui-pane-id="http" onclick="$evui.hidePane(event)">Hide</button>
+
+@section Scripts
+{
+    <script src="/js/TestScript/Window/showFromMarkup.js"></script>
+}

--- a/test/EventUITest/wwwroot/js/TestScript/Window/showFromMarkup.js
+++ b/test/EventUITest/wwwroot/js/TestScript/Window/showFromMarkup.js
@@ -1,4 +1,17 @@
 ﻿$evui.init(function ()
 {
-
+    $evui.addPane({
+        id: "http",
+        loadSettings:
+        {
+            httpLoadArgs:
+            {
+                url: "/partials/Pane/Http.html"
+            }
+        },
+        onShow: function ()
+        {
+            console.log("show")
+        }
+    })
 });


### PR DESCRIPTION
Fixing bug where a pane defined in code then shown through markup without an ID wouldn't be able to figure out what pane's settings to use.