### PR TITLE
Event rename and event argument homogenization 

### DIFF
--- a/src/raw/Modules/Binding.js
+++ b/src/raw/Modules/Binding.js
@@ -51,13 +51,13 @@ EVUI.Modules.Binding.Constants.Attr_BoundObj = "evui-binder-source";
 EVUI.Modules.Binding.Constants.Attr_Mode = "evui-binder-mode";
 EVUI.Modules.Binding.Constants.Attr_BindingTemplateName = "evui-binder-template-name";
 
-EVUI.Modules.Binding.Constants.Event_OnBind = "evui.binder.bind";
-EVUI.Modules.Binding.Constants.Event_OnSetHtmlContent = "evui.binder.get.htmlContent";
-EVUI.Modules.Binding.Constants.Event_OnSetBindings = "evui.binder.get.bindings";
-EVUI.Modules.Binding.Constants.Event_OnBindHtmlContent = "evui.binder.bind.htmlContent";
-EVUI.Modules.Binding.Constants.Event_OnBindChildren = "evui.binder.bind.children";
-EVUI.Modules.Binding.Constants.Event_OnBoundChildren = "evui.binder.bound.children";
-EVUI.Modules.Binding.Constants.Event_OnBound = "evui.binder.bound";
+EVUI.Modules.Binding.Constants.Event_OnBind = "bind";
+EVUI.Modules.Binding.Constants.Event_OnSetHtmlContent = "gethtmlContent";
+EVUI.Modules.Binding.Constants.Event_OnGetBindings = "getbindings";
+EVUI.Modules.Binding.Constants.Event_OnBindHtmlContent = "bindhtmlContent";
+EVUI.Modules.Binding.Constants.Event_OnBindChildren = "bindchildren";
+EVUI.Modules.Binding.Constants.Event_OnBoundChildren = "boundchildren";
+EVUI.Modules.Binding.Constants.Event_OnBound = "bound";
 
 /**Callback function definition for when a Binding has completed its work or was canceled.
 @param {EVUI.Modules.Binding.Binding} binding The Binding that was created or re-bound.*/
@@ -1332,14 +1332,14 @@ EVUI.Modules.Binding.BindingController = function (services)
     @param {BindingSession} session The BindingSession being executed.*/
     var addonSetBindingsSteps = function (session)
     {
-        session.eventStream.addJob(EVUI.Modules.Binding.Constants.Event_OnSetBindings, "getBindings", function (jobArgs)
+        session.eventStream.addJob(EVUI.Modules.Binding.Constants.Event_OnGetBindings, "getBindings", function (jobArgs)
         {
             onGetBindingsJob(session, jobArgs);
         });
 
         if (session.bindingHandle.currentState.parentBindingHandle != null && session.bindingHandle.currentState.parentBindingHandle.options.suppressChildEvents === true) return;
 
-        session.eventStream.addEvent(EVUI.Modules.Binding.Constants.Event_OnSetBindings, "onSetBindings", function (eventArgs)
+        session.eventStream.addEvent(EVUI.Modules.Binding.Constants.Event_OnGetBindings, "onSetBindings", function (eventArgs)
         {
             if (validateSession(session, eventArgs) === false) return;
             if (typeof session.bindingHandle.binding.onSetBindings === "function")

--- a/src/raw/Modules/Binding.js
+++ b/src/raw/Modules/Binding.js
@@ -1159,7 +1159,8 @@ EVUI.Modules.Binding.BindingController = function (services)
             var bindingArgs = new EVUI.Modules.Binding.BinderEventArgs(session);
             bindingArgs.cancel = eventStreamArgs.cancel;
             bindingArgs.context = eventStreamArgs.state;
-            bindingArgs.key = eventStreamArgs.key;
+            bindingArgs.eventType = eventStreamArgs.key;
+            bindingArgs.eventName = eventStreamArgs.name;
             bindingArgs.pause = eventStreamArgs.pause;
             bindingArgs.resume = eventStreamArgs.resume;
             bindingArgs.stopPropagation = eventStreamArgs.stopPropagation;
@@ -1177,7 +1178,7 @@ EVUI.Modules.Binding.BindingController = function (services)
         session.eventStream.onCancel = function (eventStreamArgs)
         {
             session.bindingHandle.completionState = EVUI.Modules.Binding.BindingCompletionState.Canceled;
-            //rollBackStates(session); //roll back to the previous completed state
+            rollBackStates(session); //roll back to the previous completed state
             cancelAllChildren(session); //tell all children to cancel themselves on their next step
             session.eventStream.seek(EVUI.Modules.Binding.Constants.Job_FinishBinding);
         };
@@ -1185,7 +1186,7 @@ EVUI.Modules.Binding.BindingController = function (services)
         session.eventStream.onError = function (eventStreamArgs, ex)
         {
             session.bindingHandle.completionState = EVUI.Modules.Binding.BindingCompletionState.Failed;
-            //rollBackStates(session); //roll back to the previous completed state
+            rollBackStates(session); //roll back to the previous completed state
             cancelAllChildren(session); //tell all children to cancel themselves on their next step
             session.eventStream.seek(EVUI.Modules.Binding.Constants.Job_FinishBinding);
         };
@@ -7833,28 +7834,24 @@ EVUI.Modules.Binding.BinderEventArgs = function (bindSession)
     @type {Boolean}*/
     this.reBinding = _bindSession.bindingHandle.oldStateBound;
 
-    /**Array. If this Binding has been bound more than once, this is the old content that was bound before the current binding operation.
-    @type {Node[]}*/
-    this.originalContent = (_bindSession.bindingHandle.oldState != null && _bindSession.bindingHandle.oldState.boundContent != null) ? _bindSession.bindingHandle.oldState.boundContent.slice() : null;
-
-    /**Object. The original source object that was bound to the Binding previously.
-    @type {Object}*/
-    this.originalSource = (_bindSession.bindingHandle.oldState != null) ? _bindSession.bindingHandle.oldState.source : null;
-
-    /**String. The unique key current step in the EventStream.
+    /**String. The full name of the event.
     @type {String}*/
-    this.key = null;
+    this.eventName = null;
 
-    /**Pauses the EventStream, preventing the next step from executing until resume is called.*/
+    /**String. The type of event being raised.
+    @type {String}*/
+    this.eventType = null;
+
+    /**Pauses the Binding's action, preventing the next step from executing until resume is called.*/
     this.pause = function () { };
 
-    /**Resumes the EventStream, allowing it to continue to the next step.*/
+    /**Resumes the Binding's action, allowing it to continue to the next step.*/
     this.resume = function () { };
 
-    /**Cancels the EventStream and aborts the execution of the operation.*/
+    /**Cancels the Binding's action and aborts the execution of the operation.*/
     this.cancel = function () { }
 
-    /**Stops the EventStream from calling any other event handlers with the same name.*/
+    /**Stops the Binding from calling any other event handlers with the same eventType.*/
     this.stopPropagation = function () { };
 
     /**Object. Any state value to carry between events.
@@ -7862,7 +7859,7 @@ EVUI.Modules.Binding.BinderEventArgs = function (bindSession)
     this.context = {};
 };
 
-/**The way in which the binding will be inserted into the DOM.
+/**The way in which the Binding will be inserted into the DOM.
 @enum*/
 EVUI.Modules.Binding.BindingMode =
 {
@@ -7874,7 +7871,7 @@ EVUI.Modules.Binding.BindingMode =
 
 Object.freeze(EVUI.Modules.Binding.BindingMode);
 
-/**The way in which the final product of the binding operation will be inserted relative to the Binding's element.
+/**The way in which the final product of the Binding operation will be inserted relative to the Binding's element.
 @enum*/
 EVUI.Modules.Binding.BindingInsertionMode =
 {

--- a/src/raw/Modules/Binding.js
+++ b/src/raw/Modules/Binding.js
@@ -59,14 +59,14 @@ EVUI.Modules.Binding.Constants.Event_OnBindChildren = "bindchildren";
 EVUI.Modules.Binding.Constants.Event_OnBoundChildren = "boundchildren";
 EVUI.Modules.Binding.Constants.Event_OnBound = "bound";
 
-EVUI.Modules.Binding.Constants.Job_BeginBind = "beginbind";
-EVUI.Modules.Binding.Constants.Job_GetHtmlContent = "gethtmlcontent";
-EVUI.Modules.Binding.Constants.Job_GetBindings = "getbindings";
-EVUI.Modules.Binding.Constants.Job_BindHtmlContent = "bindhtmlcontent";
-EVUI.Modules.Binding.Constants.Job_BindChildren = "bindchildren";
-EVUI.Modules.Binding.Constants.Job_ProcessChildren = "processchildren";
-EVUI.Modules.Binding.Constants.Job_Inject = "inject";
-EVUI.Modules.Binding.Constants.Job_FinishBinding = "finishbinding";
+EVUI.Modules.Binding.Constants.Job_BeginBind = "job.beginbind";
+EVUI.Modules.Binding.Constants.Job_GetHtmlContent = "job.gethtmlcontent";
+EVUI.Modules.Binding.Constants.Job_GetBindings = "job.getbindings";
+EVUI.Modules.Binding.Constants.Job_BindHtmlContent = "job.bindhtmlcontent";
+EVUI.Modules.Binding.Constants.Job_BindChildren = "job.bindchildren";
+EVUI.Modules.Binding.Constants.Job_ProcessChildren = "job.processchildren";
+EVUI.Modules.Binding.Constants.Job_Inject = "job.inject";
+EVUI.Modules.Binding.Constants.Job_FinishBinding = "job.finishbinding";
 
 EVUI.Modules.Binding.Constants.StepPrefix = "evui.binder";
 
@@ -1219,7 +1219,7 @@ EVUI.Modules.Binding.BindingController = function (services)
     var getJobName = function (jobName)
     {
         if (EVUI.Modules.Core.Utils.stringIsNullOrWhitespace(jobName) === true) throw Error("Missing jobName");
-        return EVUI.Modules.Binding.Constants.StepPrefix + ".job." + jobName;
+        return EVUI.Modules.Binding.Constants.StepPrefix + "." + jobName;
     };
 
     /**Gets the standard formatted event name for a event step in the Binder's EventStream.
@@ -1227,7 +1227,7 @@ EVUI.Modules.Binding.BindingController = function (services)
     @returns {String}*/
     var getEventName = function (eventName)
     {
-        if (EVUI.Modules.Core.Utils.stringIsNullOrWhitespace(eventName) === true) throw Error("Missing jobName");
+        if (EVUI.Modules.Core.Utils.stringIsNullOrWhitespace(eventName) === true) throw Error("Missing eventName");
         return EVUI.Modules.Binding.Constants.StepPrefix + "." + eventName;
     }
 
@@ -1852,7 +1852,7 @@ EVUI.Modules.Binding.BindingController = function (services)
                 if (session.cancel === true || session.bindingHandle.disposing === true) return eventArgs.cancel();
                 if (typeof session.bindingHandle.binding.onBound === "function")
                 {
-                    return session.bindingHandle.binding.onBound.call(eventArgs);
+                    return session.bindingHandle.binding.onBound.call(this, eventArgs);
                 }
             }
         });

--- a/src/raw/Modules/Binding.js
+++ b/src/raw/Modules/Binding.js
@@ -52,9 +52,9 @@ EVUI.Modules.Binding.Constants.Attr_Mode = "evui-binder-mode";
 EVUI.Modules.Binding.Constants.Attr_BindingTemplateName = "evui-binder-template-name";
 
 EVUI.Modules.Binding.Constants.Event_OnBind = "bind";
-EVUI.Modules.Binding.Constants.Event_OnSetHtmlContent = "gethtmlContent";
+EVUI.Modules.Binding.Constants.Event_OnSetHtmlContent = "gethtmlcontent";
 EVUI.Modules.Binding.Constants.Event_OnGetBindings = "getbindings";
-EVUI.Modules.Binding.Constants.Event_OnBindHtmlContent = "bindhtmlContent";
+EVUI.Modules.Binding.Constants.Event_OnBindHtmlContent = "bindhtmlcontent";
 EVUI.Modules.Binding.Constants.Event_OnBindChildren = "bindchildren";
 EVUI.Modules.Binding.Constants.Event_OnBoundChildren = "boundchildren";
 EVUI.Modules.Binding.Constants.Event_OnBound = "bound";

--- a/src/raw/Modules/Dialogs.js
+++ b/src/raw/Modules/Dialogs.js
@@ -132,7 +132,7 @@ EVUI.Modules.Dialogs.Constants.Attribute_Classes = "evui-dlg-class";
 EVUI.Modules.Dialogs.Constants.Default_ObjectName = "Dialog";
 EVUI.Modules.Dialogs.Constants.Default_ManagerName = "DialogManager";
 EVUI.Modules.Dialogs.Constants.Default_CssPrefix = "evui-dlg";
-EVUI.Modules.Dialogs.Constants.Default_EventNamePrefix = "evui.dlg";
+EVUI.Modules.Dialogs.Constants.Default_StepPrefix = "evui.dlg";
 EVUI.Modules.Dialogs.Constants.Default_AttributePrefix = "evui-dlg";
 
 Object.freeze(EVUI.Modules.Dialogs.Constants);
@@ -841,7 +841,7 @@ EVUI.Modules.Dialogs.DialogManager = function (services)
     _settings.attributePrefix = EVUI.Modules.Dialogs.Constants.Default_AttributePrefix;
     _settings.cssPrefix = EVUI.Modules.Dialogs.Constants.Default_CssPrefix;
     _settings.cssSheetName = EVUI.Modules.Styles.Constants.DefaultStyleSheetName;
-    _settings.eventNamePrefix = EVUI.Modules.Dialogs.Constants.Default_EventNamePrefix;
+    _settings.stepPrefix = EVUI.Modules.Dialogs.Constants.Default_StepPrefix;
     _settings.managerName = EVUI.Modules.Dialogs.Constants.Default_ManagerName;
     _settings.objectName = EVUI.Modules.Dialogs.Constants.Default_ObjectName;
     _settings.makeOrExtendObject = makeOrExtendObject;

--- a/src/raw/Modules/Dialogs.js
+++ b/src/raw/Modules/Dialogs.js
@@ -523,7 +523,8 @@ EVUI.Modules.Dialogs.DialogManager = function (services)
 
         var dialogEventArgs = new EVUI.Modules.Dialogs.DialogEventArgs(argsPackage, args);
         dialogEventArgs.cancel = paneEventArgs.cancel;
-        dialogEventArgs.key = paneEventArgs.key;
+        dialogEventArgs.eventType = paneEventArgs.eventType;
+        dialogEventArgs.eventName = paneEventArgs.eventName;
         dialogEventArgs.pause = paneEventArgs.pause;
         dialogEventArgs.resume = paneEventArgs.resume;
         dialogEventArgs.stopPropagation = paneEventArgs.stopPropagation;
@@ -913,7 +914,7 @@ EVUI.Modules.Dialogs.DialogManager = function (services)
     EVUI.Modules.Core.Utils.wrapProperties(this, _manager, { sourcePath: "onUnloaded", targetPath: "onUnloaded" });
 }
 
-/**Represents a UI component that behaves like a standard, centered dialog dialog with an optional backdrop by default.
+/**Represents a UI component that behaves like a standard, centered dialog with an optional backdrop by default.
  @class*/
 EVUI.Modules.Dialogs.Dialog = function (pane)
 {
@@ -1135,20 +1136,24 @@ EVUI.Modules.Dialogs.DialogEventArgs = function (argsPackage, currentArgs)
         enumerable: true
     });
 
-    /**String. The unique key current step in the EventStream.
+    /**String. The full name of the event.
     @type {String}*/
-    this.key = null;
+    this.eventName = null;
 
-    /**Function. Pauses the EventStream, preventing the next step from executing until resume is called.*/
+    /**String. The type of event being raised.
+    @type {String}*/
+    this.eventType = null;
+
+    /**Function. Pauses the Dialog's action, preventing the next step from executing until resume is called.*/
     this.pause = function () { };
 
-    /**Function. Resumes the EventStream, allowing it to continue to the next step.*/
+    /**Function. Resumes the Dialog's action, allowing it to continue to the next step.*/
     this.resume = function () { };
 
-    /**Function. Cancels the EventStream and aborts the execution of the Dialog operation.*/
+    /**Function. Cancels the Dialog's action and aborts the execution of the Dialog operation.*/
     this.cancel = function () { }
 
-    /**Function. Stops the EventStream from calling any other event handlers with the same key.*/
+    /**Function. Stops the Dialog from calling any other event handlers with the same eventType.*/
     this.stopPropagation = function () { };
 
     /**Object. The position of the Dialog that has been calculated in using the currentShowSettings.
@@ -1161,7 +1166,7 @@ EVUI.Modules.Dialogs.DialogEventArgs = function (argsPackage, currentArgs)
             enumerable: true
         });
 
-    /**Object. The PaneHide/Show/Load/Unload Arguments being used for the operation.
+    /**Object. The DialogHide/Show/Load/Unload Arguments being used for the operation.
     @type {EVUI.Modules.Dialogs.DialogShowArgs|EVUI.Modules.Dialogs.DialogHideArgs|EVUI.Modules.Dialogs.DialogLoadArgs|EVUI.Modules.Dialogs.DialogUnloadArgs}*/
     this.currentActionArgs = null;
     Object.defineProperty(this, "currentActionArgs", {

--- a/src/raw/Modules/Dropdowns.js
+++ b/src/raw/Modules/Dropdowns.js
@@ -506,7 +506,8 @@ EVUI.Modules.Dropdowns.DropdownManager = function (services)
 
         var dropdownEventArgs = new EVUI.Modules.Dropdowns.DropdownEventArgs(argsPackage, args);
         dropdownEventArgs.cancel = paneEventArgs.cancel;
-        dropdownEventArgs.key = paneEventArgs.key;
+        dropdownEventArgs.eventType = paneEventArgs.eventType;
+        dropdownEventArgs.eventName = paneEventArgs.eventName;
         dropdownEventArgs.pause = paneEventArgs.pause;
         dropdownEventArgs.resume = paneEventArgs.resume;
         dropdownEventArgs.stopPropagation = paneEventArgs.stopPropagation;
@@ -1110,20 +1111,24 @@ EVUI.Modules.Dropdowns.DropdownEventArgs = function (argsPackage, currentArgs)
         enumerable: true
     });
 
-    /**String. The unique key current step in the EventStream.
+    /**String. The full name of the event.
     @type {String}*/
-    this.key = null;
+    this.eventName = null;
 
-    /**Function. Pauses the EventStream, preventing the next step from executing until resume is called.*/
+    /**String. The type of event being raised.
+    @type {String}*/
+    this.eventType = null;
+
+    /**Function. Pauses the Dropdown's action, preventing the next step from executing until resume is called.*/
     this.pause = function () { };
 
-    /**Function. Resumes the EventStream, allowing it to continue to the next step.*/
+    /**Function. Resumes the Dropdown's action, allowing it to continue to the next step.*/
     this.resume = function () { };
 
-    /**Function. Cancels the EventStream and aborts the execution of the Dropdown operation.*/
+    /**Function. Cancels the Dropdown's action and aborts the execution of the Dropdown operation.*/
     this.cancel = function () { }
 
-    /**Function. Stops the EventStream from calling any other event handlers with the same key.*/
+    /**Function. Stops the Dropdown from calling any other event handlers with the same eventType.*/
     this.stopPropagation = function () { };
 
     /**Object. The position of the Dropdown that has been calculated in using the currentShowSettings.
@@ -1136,7 +1141,7 @@ EVUI.Modules.Dropdowns.DropdownEventArgs = function (argsPackage, currentArgs)
         enumerable: true
     });
 
-    /**Object. The PaneHide/Show/Load/Unload Arguments being used for the operation.
+    /**Object. The DropdownHide/Show/Load/Unload Arguments being used for the operation.
     @type {EVUI.Modules.Dropdowns.DropdownShowArgs|EVUI.Modules.Dropdowns.DropdownHideArgs|EVUI.Modules.Dropdowns.DropdownLoadArgs|EVUI.Modules.Dropdowns.DropdownUnloadArgs}*/
     this.currentActionArgs = null;
     Object.defineProperty(this, "currentActionArgs", {

--- a/src/raw/Modules/Dropdowns.js
+++ b/src/raw/Modules/Dropdowns.js
@@ -114,7 +114,7 @@ EVUI.Modules.Dropdowns.Constants.Attribute_DropMode = "evui-dd-mode"
 EVUI.Modules.Dropdowns.Constants.Default_ObjectName = "Dropdown";
 EVUI.Modules.Dropdowns.Constants.Default_ManagerName = "DropdownManager";
 EVUI.Modules.Dropdowns.Constants.Default_CssPrefix = "evui-dd";
-EVUI.Modules.Dropdowns.Constants.Default_EventNamePrefix = "evui.dd";
+EVUI.Modules.Dropdowns.Constants.Default_StepPrefix = "evui.dd";
 EVUI.Modules.Dropdowns.Constants.Default_AttributePrefix = "evui-dd";
 
 Object.freeze(EVUI.Modules.Dropdowns.Constants);
@@ -821,7 +821,7 @@ EVUI.Modules.Dropdowns.DropdownManager = function (services)
     _settings.attributePrefix = EVUI.Modules.Dropdowns.Constants.Default_AttributePrefix;
     _settings.cssPrefix = EVUI.Modules.Dropdowns.Constants.Default_CssPrefix;
     _settings.cssSheetName = EVUI.Modules.Styles.Constants.DefaultStyleSheetName;
-    _settings.eventNamePrefix = EVUI.Modules.Dropdowns.Constants.Default_EventNamePrefix;
+    _settings.stepPrefix = EVUI.Modules.Dropdowns.Constants.Default_StepPrefix;
     _settings.managerName = EVUI.Modules.Dropdowns.Constants.Default_ManagerName;
     _settings.objectName = EVUI.Modules.Dropdowns.Constants.Default_ObjectName;
     _settings.makeOrExtendObject = makeOrExtendObject;

--- a/src/raw/Modules/EventStream.js
+++ b/src/raw/Modules/EventStream.js
@@ -126,7 +126,6 @@ EVUI.Modules.EventStream.EventStream = function (config)
     @type {Boolean}*/
     this.endExecutionOnEventHandlerCrash = false;
 
-
     /**Number. The number of milliseconds to wait on each step before failing the EventStream. A negative number means no timeout. -1 by default.
     @type {Number}*/
     this.timeout = -1;
@@ -150,6 +149,10 @@ EVUI.Modules.EventStream.EventStream = function (config)
     /**Number. When the EventStream is running, this is the number of sequential steps that can be executed before introducing a shot timeout to free up the thread to allow other processes to continue, otherwise an infinite step loop (which is driven by promises) will lock the thread. Small numbers will slow down the EventStream, high numbers may result in long thread locks. 250 by default.
     @type {Number}*/
     this.skipInterval = EVUI.Modules.Core.Utils.getSetting("stepsBetweenWaits");
+
+    /**Boolean. Whether or not the steps added to the EventStream should have their properties extended onto a fresh step object.
+    @type {Boolean}*/
+    this.extendSteps = true;
 
     /**Gets the current status of the EventStream. Returns a value from EventStreamStatus.
     @returns {Number} A value from the EVUI.Modules.EventStream.EventStreamStatus enum.*/
@@ -497,7 +500,16 @@ EVUI.Modules.EventStream.EventStream = function (config)
         }
         else if (typeof step === "object")
         {
-            if (EVUI.Modules.Core.Utils.instanceOf(step, EVUI.Modules.EventStream.EventStreamStep) === false)
+            if (this.extendSteps === false)
+            {
+                streamStep = new EVUI.Modules.EventStream.EventStreamStep();
+                streamStep.handler = step.handler;
+                streamStep.key = step.key;
+                streamStep.name = step.name;
+                streamStep.timeout = step.timeout;
+                streamStep.type = step.type;
+            }
+            else if (EVUI.Modules.Core.Utils.instanceOf(step, EVUI.Modules.EventStream.EventStreamStep) === false)
             {
                 streamStep = EVUI.Modules.Core.Utils.shallowExtend(new EVUI.Modules.EventStream.EventStreamStep(), step);
             }
@@ -836,6 +848,7 @@ EVUI.Modules.EventStream.EventStream = function (config)
         config.eventState = _self.eventState;
         config.processReturnedEventArgs = _self.processReturnedEventArgs;
         config.skipInterval = _self.skipInterval;
+        config.extendSteps = _self.extendSteps;
         config.timeout = (typeof _self.timeout === "number") ? _self.timeout : -1;
         config.onComplete = function () { callback(); } //call the callback in the complete handler, which will fire no matter what.
 
@@ -1457,6 +1470,7 @@ EVUI.Modules.EventStream.EventStream = function (config)
         if (typeof config.skipInterval === "number" && config.skipInterval > 0) _self.skipInterval = config.skipInterval;
         if (typeof config.timeout === "number" && config.timeout > 0) _timeout = config.timeout;
         if (EVUI.Modules.Core.Utils.instanceOf(config.bubblingEvents, EVUI.Modules.EventStream.BubblingEventManager) === true) _self.bubblingEvents = config.bubblingEvents;
+        if (typeof config.extendSteps === "boolean") _self.extendSteps = config.extendSteps;
 
         if (typeof config.onCancel === "function") _self.onCancel = config.onCancel;
         if (typeof config.onError === "function") _self.onError = config.onError;
@@ -1794,7 +1808,13 @@ EVUI.Modules.EventStream.EventStreamConfig = function ()
     @type {EVUI.Modules.EventStream.BubblingEventManager}*/
     this.bubblingEvents = null;
 
+    /**Any. The "this" context to execute job and event handlers under.
+    @type {Any}*/
     this.context = null;
+
+    /**Boolean. Whether or not the steps added to the EventStream should have their properties extended onto a fresh step object.
+    @type {Boolean}*/
+    this.extendSteps = true;
 };
 
 /**An object that ties together an event name, its callback its priority (if there are other events with the same name) and the unique ID of it's handle.

--- a/src/raw/Modules/Events.js
+++ b/src/raw/Modules/Events.js
@@ -157,7 +157,7 @@ EVUI.Modules.Events.EventManager = function ()
         return addListener(eventListenerOrEventName, handler, priority, handlerName, EventListenerMode.FireOnce);
     };
 
-    /**Removes all the EventListeners with the given event name, callback function and/or exeuctingContext.
+    /**Removes all the EventListeners with the given event name and callback function.
     @param {String} eventNameOrIDOrHandler The name or ID of the event to remove.
     @param {EVUI.Modules.Events.Constants.Fn_Handler} handler The function that gets called when the event is invoked.*/
     this.off = function (eventNameOrId, handler)
@@ -169,16 +169,14 @@ EVUI.Modules.Events.EventManager = function ()
         {
             var curListener = _listeners[x];
 
-            if (curListener.eventListener.handlerId === eventNameOrId || curListener.eventListener.eventName === eventNameOrId)
+            if (curListener.eventListener.handlerId === eventNameOrId)
             {
-                if (typeof handler === "function")
-                {
-                    if (curListener.eventListener.handler === handler) listenersToRemove.push(curListener);
-                }
-                else
-                {
-                    listenersToRemove.push(curListener);
-                }
+                listenersToRemove.push(curListener);
+                break;
+            }
+            else if (curListener.eventListener.eventName === eventNameOrId)
+            {              
+                if (curListener.eventListener.handler === handler) listenersToRemove.push(curListener);  
             }
         }
 
@@ -235,14 +233,6 @@ EVUI.Modules.Events.EventManager = function ()
                 resolve(askResponses);
             });
         });
-    };
-
-    /**Gets all the event listeners with the given event name, callback function and/or exeuctingContext. 
-    @param {String} eventName: The name of the event to get.
-    @returns {EVUI.Modules.Events.EventListener[]}*/
-    this.getEventListeners = function (eventName)
-    {
-        return getListeners(eventName).map(function (listener) { return listener.eventListener });
     };
 
     /**Gets an event listener based on its HandlerID.
@@ -646,11 +636,6 @@ EVUI.Modules.Events.EventListener = function (eventName, handler, priority, hand
     this.handler = null;
     Object.defineProperty(this, "handler", {    
         get: function () { return _handler },
-        set: function (value)
-        {
-            if (value != null && typeof value !== "function") throw Error("handler must be a function.")
-            _handler = value;
-        },
         enumerable: true,
         configurable: false
     });
@@ -660,11 +645,6 @@ EVUI.Modules.Events.EventListener = function (eventName, handler, priority, hand
     this.priority = 0;
     Object.defineProperty(this, "priority", {
         get: function () { return _priority; },
-        set: function (value)
-        {
-            if (typeof value !== "number") throw Error("priority must be a number.");
-            _priority = value;
-        },
         enumerable: true,
         configurable: false
     });
@@ -683,11 +663,6 @@ EVUI.Modules.Events.EventListener = function (eventName, handler, priority, hand
     this.handlerName = null;
     Object.defineProperty(this, "handlerName", {
         get: function () { return _handlerName; },
-        set: function (value)
-        {
-            if (typeof value !== "string") throw Error("handlerName must be a string.");
-            _handlerName = value;
-        },
         configurable: false,
         enumerable: true
     });

--- a/src/raw/Modules/Events.js
+++ b/src/raw/Modules/Events.js
@@ -400,12 +400,12 @@ EVUI.Modules.Events.EventManager = function ()
 
         es.processInjectedEventArgs = function (eventStreamArgs)
         {
-            var eventManagerArgs = new EVUI.Modules.Events.EventManagerEventArgs(getNextListener(session, index), index + 1);
+            var eventManagerArgs = new EVUI.Modules.Events.EventManagerEventArgs(getNextListener(session, index));
             eventManagerArgs.data = session.triggerArgs.data;
-            eventManagerArgs.totalSteps = numEvents;
             eventManagerArgs.pause = eventStreamArgs.pause;
             eventManagerArgs.resume = eventStreamArgs.resume;
             eventManagerArgs.stopPropagation = eventStreamArgs.stopPropagation;
+            eventManagerArgs.triggerName = session.triggerArgs.triggerName
 
             if (session.mode === SessionMode.Ask)
             {
@@ -691,10 +691,9 @@ EVUI.Modules.Events.EventListenerAddRequest = function ()
 
 /**The object that is injected into each handler as the arguments for the event being executed. Contains the user's custom event data as well as the functionality of the async event chain.
 @class*/
-EVUI.Modules.Events.EventManagerEventArgs = function (listener, currentStepIndex)
+EVUI.Modules.Events.EventManagerEventArgs = function (listener)
 {
     var _listener = listener;
-    var _currentStep = currentStepIndex;
 
     /**Object. The EventListener that is currently being executed.
     @type {EVUI.Modules.Events.EventListener}*/
@@ -709,26 +708,17 @@ EVUI.Modules.Events.EventManagerEventArgs = function (listener, currentStepIndex
     @type {Any}*/
     this.data = null;
 
-    /**Number. The index of the current step in the sequence of events.
-    @type {Number}*/
-    this.currentStep = -1;
-    Object.defineProperty(this, "currentStep", {
-        get: function () { return _currentStep; },
-        configurable: false,
-        enumerable: true
-    });
+    /**String. An identifier given for trigger of this event.
+    @type {String}*/
+    this.triggerName = null;
 
-    /**Number. The total number of events in the event sequence.
-    @type {Number}*/
-    this.totalSteps = -1;
-
-    /**Function. Pauses the EventStream, preventing the next step from executing until resume is called.*/
+    /**Function. Pauses the EventListener's action, preventing the next step from executing until resume is called.*/
     this.pause = function () { };
 
-    /**Function. Resumes the EventStream, allowing it to continue to the next step.*/
+    /**Function. Resumes the EventListener's action, allowing it to continue to the next step.*/
     this.resume = function () { };
 
-    /**Function. Stops the EventStream from calling any other event handlers with the same key.*/
+    /**Function. Stops the EventManager from calling any other event handlers with the same eventType.*/
     this.stopPropagation = function () { };
 };
 

--- a/src/raw/Modules/HtmlLoader.js
+++ b/src/raw/Modules/HtmlLoader.js
@@ -43,9 +43,9 @@ Object.freeze(EVUI.Modules.HtmlLoader.Dependencies);
 
 EVUI.Modules.HtmlLoader.Constants = {};
 
-EVUI.Modules.HtmlLoader.Constants.Job_GetHtml = "evui.htmlLoader.getHtml";
-EVUI.Modules.HtmlLoader.Constants.Job_InjectHtml = "evui.htmlLoader.injectHtml";
-EVUI.Modules.HtmlLoader.Constants.Job_LoadChildren = "evui.htmlLoader.loadChildren";
+EVUI.Modules.HtmlLoader.Constants.Job_GetHtml = "job.getHtml";
+EVUI.Modules.HtmlLoader.Constants.Job_InjectHtml = "job.injectHtml";
+EVUI.Modules.HtmlLoader.Constants.Job_LoadChildren = "job.loadChildren";
 
 EVUI.Modules.HtmlLoader.Constants.Attr_PlaceholderID = "evui-loader-placeholder-id";
 EVUI.Modules.HtmlLoader.Constants.Attr_ResourceUrl = "evui-loader-placeholder-src";
@@ -58,7 +58,7 @@ EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren = "loadchildren";
 EVUI.Modules.HtmlLoader.Constants.Event_OnLoaded = "loaded";
 EVUI.Modules.HtmlLoader.Constants.Event_OnComplete = "complete"
 
-EVUI.Modules.HtmlLoader.Constants.EventNamePrefix = "evui.htmlloader";
+EVUI.Modules.HtmlLoader.Constants.StepPrefix = "evui.htmlloader";
 
 /**Callback function that is called when Html is returned from a web request.
 @param {String} html: The Html returned from the web request.*/
@@ -672,7 +672,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
     {
         session.eventStream.addStep({
             key: EVUI.Modules.HtmlLoader.Constants.Event_OnLoad,
-            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoad,
+            name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoad,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -685,7 +685,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
 
         session.eventStream.addStep({
             key: EVUI.Modules.HtmlLoader.Constants.Event_OnLoad,
-            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoad,
+            name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoad,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {
@@ -704,7 +704,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
         session.eventStream.addStep(
             {
                 key: EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren,
-                name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren,
+                name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren,
                 type: EVUI.Modules.EventStream.EventStreamStepType.Event,
                 handler: function (eventArgs)
                 {
@@ -718,7 +718,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
         session.eventStream.addStep(
             {
                 key: EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren,
-                name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren,
+                name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren,
                 type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
                 handler: function (eventArgs)
                 {
@@ -737,7 +737,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
     {
         session.eventStream.addStep({
             key: EVUI.Modules.HtmlLoader.Constants.Event_OnInject,
-            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnInject,
+            name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnInject,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -750,7 +750,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
 
         session.eventStream.addStep({
             key: EVUI.Modules.HtmlLoader.Constants.Event_OnInject,
-            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnInject,
+            name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnInject,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {
@@ -768,7 +768,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
     {
         session.eventStream.addStep({
             key: EVUI.Modules.HtmlLoader.Constants.Event_OnLoaded,
-            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoaded,
+            name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoaded,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -781,7 +781,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
 
         session.eventStream.addStep({
             key: EVUI.Modules.HtmlLoader.Constants.Event_OnLoaded,
-            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoaded,
+            name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoaded,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {
@@ -801,7 +801,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
         {
             session.eventStream.addStep({
                 key: EVUI.Modules.HtmlLoader.Constants.Event_OnComplete,
-                name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnComplete,
+                name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnComplete,
                 type: EVUI.Modules.EventStream.EventStreamStepType.Event,
                 handler: function (eventArgs)
                 {
@@ -813,8 +813,8 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
             });
 
             session.eventStream.addStep({
-                key: EVUI.Modules.HtmlLoader.Constants.Event_OnAllPlaceholdersLoaded,
-                name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnComplete,
+                key: EVUI.Modules.HtmlLoader.Constants.Event_OnComplete,
+                name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnComplete,
                 type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
                 handler: function (eventArgs)
                 {
@@ -844,7 +844,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
         //add the "get Html" step that invokes the HttpEventStream to perform the http operation.
         eventStream.addStep({
             key: EVUI.Modules.HtmlLoader.Constants.Job_GetHtml,
-            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Job_GetHtml,
+            name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Job_GetHtml,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
             {
@@ -895,7 +895,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
         //launches a volley of parallel event streams to go and load all the child placeholders of this placeholder. Remains in limbo until all the children are done.
         eventStream.addStep({
             key: EVUI.Modules.HtmlLoader.Constants.Job_LoadChildren,
-            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Job_LoadChildren,
+            name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Job_LoadChildren,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
             {
@@ -947,7 +947,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
         //inject the html into the placeholder element
         eventStream.addStep({
             key: EVUI.Modules.HtmlLoader.Constants.Job_InjectHtml,
-            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Job_InjectHtml,
+            name: EVUI.Modules.HtmlLoader.Constants.StepPrefix + "." + EVUI.Modules.HtmlLoader.Constants.Job_InjectHtml,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
             {

--- a/src/raw/Modules/HtmlLoader.js
+++ b/src/raw/Modules/HtmlLoader.js
@@ -631,12 +631,13 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
         session.eventStream.processInjectedEventArgs = function (eventArgs)
         {
             var htmlArgs = new EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadEventArgs();
+            htmlArgs.eventName = eventArgs.name;
+            htmlArgs.eventType = eventArgs.key;
             htmlArgs.cancel = eventArgs.cancel;
             htmlArgs.pause = eventArgs.pause;
             htmlArgs.resume = eventArgs.resume;
             htmlArgs.stopPropagation = eventArgs.stopPropagation;
             htmlArgs.context = eventArgs.state;
-            htmlArgs.key = eventArgs.key + ((eventArgs.stepType === EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent) ? ".global" : "");
             htmlArgs.placeholder = session.placeholder;
 
             return htmlArgs;
@@ -1202,25 +1203,32 @@ EVUI.Modules.HtmlLoader.HtmlPartialLoadArgs = function ()
 @class*/
 EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadEventArgs = function ()
 {
-    /**Object. The HtmlPlaceholderLoadArgs being used to load placeholders.
-    @type {EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadArgs}*/
+    /**Object. The HtmlPlaceholder being used to load placeholders.
+    @type {EVUI.Modules.HtmlLoader.HtmlPlaceholder}*/
     this.placeholder = null;
 
     /**Object. The context object for this event that gets passed between events. 
     @type {Any}*/
     this.context = null;
 
-    /**Pauses the load/injection process indefinitely until Resume is called.
-    @method Pause*/
+    /**String. The full name of the event.
+    @type {String}*/
+    this.eventName = null;
+
+    /**String. The type of event being raised.
+    @type {String}*/
+    this.eventType = null;
+
+    /**Pauses the HtmlPlaceholder's action, preventing the next step from executing until resume is called.*/
     this.pause = function () { };
-    /**Resumes a paused load/injection process.
-    @method Resume*/
+
+    /**Resumes the HtmlPlaceholder's action, allowing it to continue to the next step.*/
     this.resume = function () { };
-    /**Cancels the load/injection process at its current state.
-    @method Cancel*/
-    this.cancel = function () { };
-    /**Prevents any further events with the same key from being executed.
-    @method StopPropagation*/
+
+    /**Cancels the HtmlPlaceholder's action and aborts the execution of the operation.*/
+    this.cancel = function () { }
+
+    /**Stops the HtmlPlaceholder from calling any other event handlers with the same eventType.*/
     this.stopPropagation = function () { };
 };
 

--- a/src/raw/Modules/HtmlLoader.js
+++ b/src/raw/Modules/HtmlLoader.js
@@ -19,7 +19,8 @@ EVUI.Modules.HtmlLoader.Dependencies =
 {
     Core: Object.freeze({ version: "1.0", required: true }),
     EventStream: Object.freeze({ version: "1.0", required: true }),
-    Http: Object.freeze({ version: "1.0", required: true })
+    Http: Object.freeze({ version: "1.0", required: true }),
+    DomTree: Object.freeze({version: "1.0", required: false})
 };
 
 (function ()
@@ -50,12 +51,14 @@ EVUI.Modules.HtmlLoader.Constants.Attr_PlaceholderID = "evui-loader-placeholder-
 EVUI.Modules.HtmlLoader.Constants.Attr_ResourceUrl = "evui-loader-placeholder-src";
 EVUI.Modules.HtmlLoader.Constants.Attr_ContentLoadState = "evui-loader-content-load-state";
 
-EVUI.Modules.HtmlLoader.Constants.Event_OnBeforePlaceholderLoad = "evui.htmlLoader.onBeforeLoad";
-EVUI.Modules.HtmlLoader.Constants.Event_OnGetPlaceholderHtml = "evui.htmlLoader.onGetPlaceholderHtml";
-EVUI.Modules.HtmlLoader.Constants.Event_OnPlaceholderInject = "evui.htmlLoader.onInject";
-EVUI.Modules.HtmlLoader.Constants.Event_OnBeforeLoadPlaceholderChildren = "evui.htmlLoader.onBeforeLoadChildren";
-EVUI.Modules.HtmlLoader.Constants.Event_OnPlaceholderLoaded = "evui.htmlLoader.onPlaceholderLoaded";
-EVUI.Modules.HtmlLoader.Constants.Event_OnAllPlaceholdersLoaded = "evui.hmlLoader.onAllPlaceholdersLoaded"
+EVUI.Modules.HtmlLoader.Constants.Event_OnLoad = "load";
+EVUI.Modules.HtmlLoader.Constants.Event_OnGetHtml = "gethtml";
+EVUI.Modules.HtmlLoader.Constants.Event_OnInject = "inject";
+EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren = "loadchildren";
+EVUI.Modules.HtmlLoader.Constants.Event_OnLoaded = "loaded";
+EVUI.Modules.HtmlLoader.Constants.Event_OnComplete = "complete"
+
+EVUI.Modules.HtmlLoader.Constants.EventNamePrefix = "evui.htmlloader";
 
 /**Callback function that is called when Html is returned from a web request.
 @param {String} html: The Html returned from the web request.*/
@@ -642,7 +645,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
         //set up the logic for handling the filtration of child members by the user
         session.eventStream.processReturnedEventArgs = function (htmlArgs, handlerResult, step)
         {
-            if (step.key === EVUI.Modules.HtmlLoader.Constants.Event_OnBeforeLoadPlaceholderChildren)
+            if (step.key === EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren)
             {
                 session.selectedChildPlaceholders = getSelectedChildPlaceholders(session.allChildPlaceholders);
             }
@@ -667,33 +670,31 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
     @param {PlaceholderLoadSession} session Context data about the placeholder load operation in progress. */
     var addOnBeforeLoadEvents = function (session)
     {
-        session.eventStream.addStep(
+        session.eventStream.addStep({
+            key: EVUI.Modules.HtmlLoader.Constants.Event_OnLoad,
+            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoad,
+            type: EVUI.Modules.EventStream.EventStreamStepType.Event,
+            handler: function (eventArgs)
             {
-                key: EVUI.Modules.HtmlLoader.Constants.Event_OnBeforePlaceholderLoad,
-                name: "onBeforePlaceholderLoad",
-                type: EVUI.Modules.EventStream.EventStreamStepType.Event,
-                handler: function (eventArgs)
+                if (typeof session.placeholderArgs.onLoad === "function")
                 {
-                    if (typeof session.placeholderArgs.onBeforePlaceholderLoad === "function")
-                    {
-                        return session.placeholderArgs.onBeforePlaceholderLoad(eventArgs);
-                    }
+                    return session.placeholderArgs.onLoad.call(this, eventArgs);
                 }
-            });
+            }
+        });
 
-        session.eventStream.addStep(
+        session.eventStream.addStep({
+            key: EVUI.Modules.HtmlLoader.Constants.Event_OnLoad,
+            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoad,
+            type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
+            handler: function (eventArgs)
             {
-                key: EVUI.Modules.HtmlLoader.Constants.Event_OnBeforePlaceholderLoad,
-                name: "onBeforePlaceholderLoad",
-                type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
-                handler: function (eventArgs)
+                if (typeof _self.onLoad === "function")
                 {
-                    if (typeof _self.onBeforePlaceholderLoad === "function")
-                    {
-                        return _self.onBeforePlaceholderLoad(eventArgs);
-                    }
+                    return _self.onLoad.call(_self, eventArgs);
                 }
-            });
+            }
+        });
     };
 
     /**Adds the "OnBeforeLoadChildren" events that give the user an opportunity to filter the list of child placeholders that will be loaded.
@@ -702,28 +703,28 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
     {
         session.eventStream.addStep(
             {
-                key: EVUI.Modules.HtmlLoader.Constants.Event_OnBeforeLoadPlaceholderChildren,
-                name: "onBeforeLoadPlaceholderChildren",
+                key: EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren,
+                name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren,
                 type: EVUI.Modules.EventStream.EventStreamStepType.Event,
                 handler: function (eventArgs)
                 {
-                    if (typeof session.placeholderArgs.onBeforeLoadPlaceholderChildren === "function")
+                    if (typeof session.placeholderArgs.onLoadChildren === "function")
                     {
-                        return session.placeholderArgs.onBeforeLoadPlaceholderChildren(eventArgs);
+                        return session.placeholderArgs.onLoadChildren.call(this, eventArgs);
                     }
                 }
             });
 
         session.eventStream.addStep(
             {
-                key: EVUI.Modules.HtmlLoader.Constants.Event_OnBeforeLoadPlaceholderChildren,
-                name: "onBeforeLoadPlaceholderChildren",
+                key: EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren,
+                name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoadChildren,
                 type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
                 handler: function (eventArgs)
                 {
-                    if (typeof _self.onBeforeLoadPlaceholderChildren === "function")
+                    if (typeof _self.onLoadChildren === "function")
                     {
-                        return _self.onBeforeLoadPlaceholderChildren(eventArgs);
+                        return _self.onLoadChildren.call(_self, eventArgs);
                     }
 
                 }
@@ -734,66 +735,62 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
     @param {PlaceholderLoadSession} session Context data about the placeholder load operation in progress. */
     var addOnInjectEvents = function (session)
     {
-        session.eventStream.addStep(
+        session.eventStream.addStep({
+            key: EVUI.Modules.HtmlLoader.Constants.Event_OnInject,
+            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnInject,
+            type: EVUI.Modules.EventStream.EventStreamStepType.Event,
+            handler: function (eventArgs)
             {
-                key: EVUI.Modules.HtmlLoader.Constants.Event_OnPlaceholderInject,
-                name: "onPlaceholderInject",
-                type: EVUI.Modules.EventStream.EventStreamStepType.Event,
-                handler: function (eventArgs)
+                if (typeof session.placeholderArgs.onInject === "function")
                 {
-                    if (typeof session.placeholderArgs.onPlaceholderInject === "function")
-                    {
-                        return session.placeholderArgs.onPlaceholderInject(eventArgs);
-                    }
+                    return session.placeholderArgs.onInject.call(this, eventArgs);
                 }
-            });
+            }
+        });
 
-        session.eventStream.addStep(
+        session.eventStream.addStep({
+            key: EVUI.Modules.HtmlLoader.Constants.Event_OnInject,
+            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnInject,
+            type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
+            handler: function (eventArgs)
             {
-                key: EVUI.Modules.HtmlLoader.Constants.Event_OnPlaceholderInject,
-                name: "onPlaceholderInject",
-                type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
-                handler: function (eventArgs)
+                if (typeof _self.onInject === "function")
                 {
-                    if (typeof _self.onPlaceholderInject === "function")
-                    {
-                        return _self.onPlaceholderInject(eventArgs);
-                    }
+                    return _self.onInject.call(_self, eventArgs);
                 }
-            });
+            }
+        });
     };
 
     /**Adds the "OnPlaceholderLoaded" events that give the user an opportunity to inspect/react to the final loaded result in the session's parent.
     @param {PlaceholderLoadSession} session Context data about the placeholder load operation in progress. */
     var addOnPlaceholderLoadedEvents = function (session)
     {
-        session.eventStream.addStep(
+        session.eventStream.addStep({
+            key: EVUI.Modules.HtmlLoader.Constants.Event_OnLoaded,
+            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoaded,
+            type: EVUI.Modules.EventStream.EventStreamStepType.Event,
+            handler: function (eventArgs)
             {
-                key: EVUI.Modules.HtmlLoader.Constants.Event_OnPlaceholderLoaded,
-                name: "onPlaceholderLoaded",
-                type: EVUI.Modules.EventStream.EventStreamStepType.Event,
-                handler: function (eventArgs)
+                if (typeof session.placeholderArgs.onLoaded === "function")
                 {
-                    if (typeof session.placeholderArgs.onPlaceholderLoaded === "function")
-                    {
-                        return session.placeholderArgs.onPlaceholderLoaded(eventArgs);
-                    }
+                    return session.placeholderArgs.onLoaded.call(this, eventArgs);
                 }
-            });
+            }
+        });
 
-        session.eventStream.addStep(
+        session.eventStream.addStep({
+            key: EVUI.Modules.HtmlLoader.Constants.Event_OnLoaded,
+            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnLoaded,
+            type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
+            handler: function (eventArgs)
             {
-                key: EVUI.Modules.HtmlLoader.Constants.Event_OnPlaceholderLoaded,
-                name: "onPlaceholderLoaded",
-                type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
-                handler: function (eventArgs)
+                if (typeof _self.onLoaded === "function")
                 {
-                    if (typeof _self.onPlaceholderLoaded === "function")
-                    {
-                        return _self.onPlaceholderLoaded(eventArgs);
-                    }
+                    return _self.onLoaded.call(_self, eventArgs);
                 }
-            });
+            }
+        });
     };
 
     /**Adds the "OnAllPlaceholderLoaded" events that fire once the highest parent session has completed loading and signals that the operation is complete.
@@ -802,33 +799,31 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
     {
         if (session.parentSession == null)
         {
-            session.eventStream.addStep(
+            session.eventStream.addStep({
+                key: EVUI.Modules.HtmlLoader.Constants.Event_OnComplete,
+                name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnComplete,
+                type: EVUI.Modules.EventStream.EventStreamStepType.Event,
+                handler: function (eventArgs)
                 {
-                    key: EVUI.Modules.HtmlLoader.Constants.Event_OnAllPlaceholdersLoaded,
-                    name: "onAllPlaceholdersLoaded",
-                    type: EVUI.Modules.EventStream.EventStreamStepType.Event,
-                    handler: function (eventArgs)
+                    if (typeof session.placeholderArgs.onComplete === "function")
                     {
-                        if (typeof session.placeholderArgs.onAllPlaceholdersLoaded === "function")
-                        {
-                            return session.placeholderArgs.onAllPlaceholdersLoaded(eventArgs);
-                        }
+                        return session.placeholderArgs.onComplete.call(this, eventArgs);
                     }
-                });
+                }
+            });
 
-            session.eventStream.addStep(
+            session.eventStream.addStep({
+                key: EVUI.Modules.HtmlLoader.Constants.Event_OnAllPlaceholdersLoaded,
+                name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Event_OnComplete,
+                type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
+                handler: function (eventArgs)
                 {
-                    key: EVUI.Modules.HtmlLoader.Constants.Event_OnAllPlaceholdersLoaded,
-                    name: "onAllPlaceholdersLoaded",
-                    type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
-                    handler: function (eventArgs)
+                    if (typeof _self.onComplete === "function")
                     {
-                        if (typeof _self.onAllPlaceholdersLoaded === "function")
-                        {
-                            return _self.onAllPlaceholdersLoaded(eventArgs);
-                        }
+                        return _self.onComplete.call(_self, eventArgs);
                     }
-                });
+                }
+            });
         }
     }
 
@@ -847,138 +842,135 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
         addOnBeforeLoadEvents(session);
 
         //add the "get Html" step that invokes the HttpEventStream to perform the http operation.
-        eventStream.addStep(
+        eventStream.addStep({
+            key: EVUI.Modules.HtmlLoader.Constants.Job_GetHtml,
+            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Job_GetHtml,
+            type: EVUI.Modules.EventStream.EventStreamStepType.Job,
+            handler: function (jobArgs)
             {
-                key: EVUI.Modules.HtmlLoader.Constants.Job_GetHtml,
-                name: "GetHtml",
-                type: EVUI.Modules.EventStream.EventStreamStepType.Job,
-                handler: function (jobArgs)
-                {
-                    var placeholderAttrs = EVUI.Modules.Core.Utils.getElementAttributes(session.placeholderElement);
-                    var loadState = placeholderAttrs.getValue(EVUI.Modules.HtmlLoader.Constants.Attr_ContentLoadState);
+                var placeholderAttrs = EVUI.Modules.Core.Utils.getElementAttributes(session.placeholderElement);
+                var loadState = placeholderAttrs.getValue(EVUI.Modules.HtmlLoader.Constants.Attr_ContentLoadState);
 
-                    //check to make sure the load state isn't already "loaded" - only re-load it if ForceReload is true. Otherwise, just bail and go to the end of the event stream.
-                    if (loadState != null && loadState.toLowerCase() === EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Loaded && session.placeholderArgs.forceReload === false)
+                //check to make sure the load state isn't already "loaded" - only re-load it if ForceReload is true. Otherwise, just bail and go to the end of the event stream.
+                if (loadState != null && loadState.toLowerCase() === EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Loaded && session.placeholderArgs.forceReload === false)
+                {
+                    return jobArgs.cancel();
+                }
+
+                //get the URL off of the element. It doesn't actually have to be there and can be set/changed in the HttpEventStream's EventStream.
+                var url = placeholderAttrs.getValue(EVUI.Modules.HtmlLoader.Constants.Attr_ResourceUrl);
+
+                var htmlArgs = new EVUI.Modules.HtmlLoader.HtmlRequestArgs();
+                htmlArgs.url = url;
+                htmlArgs.httpArgs = session.placeholderArgs.httpArgs;
+
+                _self.loadHtml(htmlArgs, function (html)
+                {
+                    if (html != null) //call worked, we got a string back
                     {
-                        return jobArgs.cancel();
+                        var docFrag = stringToDocFrag(html); //make  a document fragment out of the string
+                        session.loadedFragment = docFrag;
+                        session.html = html;
+                        session.url = htmlArgs.url
+
+                        if (session.placeholderArgs.recursive === true) //we're doing a recursive load, go get all the children flagged with a placeholder ID
+                        {
+                            session.allChildPlaceholders = getLoadableElements(docFrag, session.placeholderArgs.forceReload, session.placeholderArgs.ignoreOnDemand);
+                            session.selectedChildPlaceholders = session.allChildPlaceholders.slice();
+                        }
+                        else //no recursion, just use empty arrays to make the event args generator happy
+                        {
+                            session.allChildPlaceholders = [];
+                            session.selectedChildPlaceholders = [];
+                        }
                     }
 
-                    //get the URL off of the element. It doesn't actually have to be there and can be set/changed in the HttpEventStream's EventStream.
-                    var url = placeholderAttrs.getValue(EVUI.Modules.HtmlLoader.Constants.Attr_ResourceUrl);
-
-                    var htmlArgs = new EVUI.Modules.HtmlLoader.HtmlRequestArgs();
-                    htmlArgs.url = url;
-                    htmlArgs.httpArgs = session.placeholderArgs.httpArgs;
-
-                    _self.loadHtml(htmlArgs, function (html)
-                    {
-                        if (html != null) //call worked, we got a string back
-                        {
-                            var docFrag = stringToDocFrag(html); //make  a document fragment out of the string
-                            session.loadedFragment = docFrag;
-                            session.html = html;
-                            session.url = htmlArgs.url
-
-                            if (session.placeholderArgs.recursive === true) //we're doing a recursive load, go get all the children flagged with a placeholder ID
-                            {
-                                session.allChildPlaceholders = getLoadableElements(docFrag, session.placeholderArgs.forceReload, session.placeholderArgs.ignoreOnDemand);
-                                session.selectedChildPlaceholders = session.allChildPlaceholders.slice();
-                            }
-                            else //no recursion, just use empty arrays to make the event args generator happy
-                            {
-                                session.allChildPlaceholders = [];
-                                session.selectedChildPlaceholders = [];
-                            }
-                        }
-
-                        return jobArgs.resolve();
-                    });
-                }
-            });
+                    return jobArgs.resolve();
+                });
+            }
+        });
 
         addOnBeforeLoadChildrenEvents(session);
 
         //launches a volley of parallel event streams to go and load all the child placeholders of this placeholder. Remains in limbo until all the children are done.
-        eventStream.addStep(
+        eventStream.addStep({
+            key: EVUI.Modules.HtmlLoader.Constants.Job_LoadChildren,
+            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Job_LoadChildren,
+            type: EVUI.Modules.EventStream.EventStreamStepType.Job,
+            handler: function (jobArgs)
             {
-                key: EVUI.Modules.HtmlLoader.Constants.Job_LoadChildren,
-                name: "LoadChildren",
-                type: EVUI.Modules.EventStream.EventStreamStepType.Job,
-                handler: function (jobArgs)
+                var numChildSessions = session.selectedChildPlaceholders.length;
+                if (numChildSessions === 0) //no children, just continue to the next step
                 {
-                    var numChildSessions = session.selectedChildPlaceholders.length;
-                    if (numChildSessions === 0) //no children, just continue to the next step
-                    {
-                        return jobArgs.resolve();
-                    }
-
-                    var actualChildren = [];
-                    var numLoaded = 0;
-
-                    for (var x = 0; x < numChildSessions; x++)
-                    {
-                        var curChild = session.selectedChildPlaceholders[x];
-                        var attrs = EVUI.Modules.Core.Utils.getElementAttributes(curChild);
-
-                        var placeholderID = attrs.getValue(EVUI.Modules.HtmlLoader.Constants.Attr_PlaceholderID);
-                        if (EVUI.Modules.Core.Utils.stringIsNullOrWhitespace(placeholderID) === true) continue; //no placeholder ID, should not load child (we could, but we wont.)
-
-                        var childSession = makePlaceholderLoadSession(curChild, session.placeholderArgs, session, function (loadResult) //make a child session using this session's arguments
-                        {
-                            numLoaded++;
-                            if (numLoaded === session.childSessions.length) //the loaded results and the number of queued sessions is the same, we're done. This stream can move on to the next step.
-                            {
-                                jobArgs.resolve();
-                            }
-                        });
-
-                        if (childSession == null) continue; //for some reason the child session was not created (usually a validation failure)
-
-                        actualChildren.push(curChild);
-
-                        curChild.setAttribute(EVUI.Modules.HtmlLoader.Constants.Attr_ContentLoadState, EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Loading);
-                        session.loadState = EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Loading;
-                        childSession.eventStream.execute(); //kick off the child load process.
-                    }
-
-                    session.selectedChildPlaceholders = actualChildren;
-                    if (actualChildren.length === 0) //no children were queued to be loaded, just continue to the next step.
-                    {
-                        return jobArgs.resolve();
-                    }
+                    return jobArgs.resolve();
                 }
-            });
+
+                var actualChildren = [];
+                var numLoaded = 0;
+
+                for (var x = 0; x < numChildSessions; x++)
+                {
+                    var curChild = session.selectedChildPlaceholders[x];
+                    var attrs = EVUI.Modules.Core.Utils.getElementAttributes(curChild);
+
+                    var placeholderID = attrs.getValue(EVUI.Modules.HtmlLoader.Constants.Attr_PlaceholderID);
+                    if (EVUI.Modules.Core.Utils.stringIsNullOrWhitespace(placeholderID) === true) continue; //no placeholder ID, should not load child (we could, but we wont.)
+
+                    var childSession = makePlaceholderLoadSession(curChild, session.placeholderArgs, session, function (loadResult) //make a child session using this session's arguments
+                    {
+                        numLoaded++;
+                        if (numLoaded === session.childSessions.length) //the loaded results and the number of queued sessions is the same, we're done. This stream can move on to the next step.
+                        {
+                            jobArgs.resolve();
+                        }
+                    });
+
+                    if (childSession == null) continue; //for some reason the child session was not created (usually a validation failure)
+
+                    actualChildren.push(curChild);
+
+                    curChild.setAttribute(EVUI.Modules.HtmlLoader.Constants.Attr_ContentLoadState, EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Loading);
+                    session.loadState = EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Loading;
+                    childSession.eventStream.execute(); //kick off the child load process.
+                }
+
+                session.selectedChildPlaceholders = actualChildren;
+                if (actualChildren.length === 0) //no children were queued to be loaded, just continue to the next step.
+                {
+                    return jobArgs.resolve();
+                }
+            }
+        });
 
         addOnInjectEvents(session);
 
         //inject the html into the placeholder element
-        eventStream.addStep(
+        eventStream.addStep({
+            key: EVUI.Modules.HtmlLoader.Constants.Job_InjectHtml,
+            name: EVUI.Modules.HtmlLoader.Constants.EventNamePrefix + "." + EVUI.Modules.HtmlLoader.Constants.Job_InjectHtml,
+            type: EVUI.Modules.EventStream.EventStreamStepType.Job,
+            handler: function (jobArgs)
             {
-                key: EVUI.Modules.HtmlLoader.Constants.Job_InjectHtml,
-                name: "InjectHtml",
-                type: EVUI.Modules.EventStream.EventStreamStepType.Job,
-                handler: function (jobArgs)
+                if (session.loadedFragment != null) //we have content, blow away old content and replace it with new content
                 {
-                    if (session.loadedFragment != null) //we have content, blow away old content and replace it with new content
-                    {
-                        var eh = new EVUI.Modules.Dom.DomHelper(session.placeholderElement);
-                        eh.empty();
+                    var eh = new EVUI.Modules.Dom.DomHelper(session.placeholderElement);
+                    eh.empty();
 
-                        var injected = eh.append(session.loadedFragment);
-                        session.loadedContent = injected.elements;
+                    var injected = eh.append(session.loadedFragment);
+                    session.loadedContent = injected.elements;
 
-                        eh.attr(EVUI.Modules.HtmlLoader.Constants.Attr_ContentLoadState, EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Loaded); //set the load state so this placeholder isn't loaded again
-                        session.loadState = EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Loaded;
-                    }
-                    else //no content, flag it as failed
-                    {
-                        session.placeholderElement.setAttribute(EVUI.Modules.HtmlLoader.Constants.Attr_ContentLoadState, EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Failed);
-                        session.loadState = EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Failed;
-                    }
-
-                    jobArgs.resolve();
+                    eh.attr(EVUI.Modules.HtmlLoader.Constants.Attr_ContentLoadState, EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Loaded); //set the load state so this placeholder isn't loaded again
+                    session.loadState = EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Loaded;
                 }
-            });
+                else //no content, flag it as failed
+                {
+                    session.placeholderElement.setAttribute(EVUI.Modules.HtmlLoader.Constants.Attr_ContentLoadState, EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Failed);
+                    session.loadState = EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadState.Failed;
+                }
+
+                jobArgs.resolve();
+            }
+        });
 
         addOnPlaceholderLoadedEvents(session);
         addOnAllPlaceholderLoadedEvents(session);
@@ -991,6 +983,14 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
     @returns {DocumentFragment} */
     var stringToDocFrag = function (str)
     {
+        if (_services.domTree != null)
+        {
+            var frag = _services.domTree.htmlToDocumentFragment(str);
+            if (frag == null) frag = document.createDocumentFragment();
+
+            return frag;
+        }
+
         var div = document.createElement("div");
         div.innerHTML = str;
 
@@ -1005,6 +1005,7 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
         return docFrag;
     };
 
+    /**Ensures that the _services object is populated with the default values if none were specified.*/
     var ensureServices = function ()
     {
         if (_services == null || typeof _services !== "object")
@@ -1023,39 +1024,52 @@ EVUI.Modules.HtmlLoader.HtmlLoaderController = function (services)
                 enumerable: true
             })
         }
+
+        if (_services.domTree == null || typeof _services.domTree !== "object")
+        {
+            Object.defineProperty(_services, "domTree", {
+                get: function ()
+                {
+                    if (EVUI.Modules.DomTree == null) return null;
+                    return EVUI.Modules.DomTree.Converter;
+                },
+                configurable: false,
+                enumerable: true
+            })
+        }
     };
 
     /**Event that executes before the request to get HTML from the server has been sent and gives the opportunity to stop the operation before it begins.
     @param {EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadEventArgs} args: An instance of EVUI.Modules.HtmlLoaderController.HtmlPlaceholderLoadEventArgs describing the current load operation.*/
-    this.onBeforePlaceholderLoad = function (args)
+    this.onLoad = function (args)
     {
 
     };
 
     /**Event that executes before the HTML returned from the server is injected into the DOM and gives the user the ability to manipulate the HTML while it is still in a document fragment.
     @param {EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadEventArgs} args: An instance of EVUI.Modules.HtmlLoaderController.HtmlPlaceholderLoadEventArgs describing the current load operation.*/
-    this.onPlaceholderInject = function (args)
+    this.onInject = function (args)
     {
 
     };
 
     /**Event that executes before any recursive child loads occur and gives the user the opportunity to edit the list of children being theoretically loaded.
     @param {EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadEventArgs} args: An instance of EVUI.Modules.HtmlLoaderController.HtmlPlaceholderLoadEventArgss describing the current load operation.*/
-    this.onBeforeLoadPlaceholderChildren = function (args)
+    this.onLoadChildren = function (args)
     {
 
     };
 
     /**Event that executes after the placeholder - and all of its children - have been injected and the load operation is complete.
     @param {EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadEventArgs} args: An instance of EVUI.Modules.HtmlLoaderController.HtmlPlaceholderLoadEventArgs describing the current load operation.*/
-    this.onPlaceholderLoaded = function (args)
+    this.onLoaded = function (args)
     {
 
     };
 
     /**Event that executes after all the placeholders have been loaded recursively.
     @param {EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadEventArgs} args: An instance of EVUI.Modules.HtmlLoaderController.HtmlPlaceholderLoadEventArgs describing the current load operation.*/
-    this.onAllPlaceholdersLoaded = function (args)
+    this.onComplete = function (args)
     {
 
     };
@@ -1256,34 +1270,34 @@ EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadArgs = function ()
 
     /**Event that executes before the request to get HTML from the server has been sent and gives the opportunity to stop the operation before it begins.
     les.HtmlLoaderController.HtmlPlaceholderLoadEventArgs} args: An instance of EVUI.Modules.HtmlLoaderController.HtmlPlaceholderLoadEventArgs describing the current load operation.*/
-    this.onBeforePlaceholderLoad = function (args)
+    this.onLoad = function (args)
     {
 
     };
 
     /**Event that executes before any recursive child loads occur and gives the user the opportunity to edit the list of children being theoretically loaded.
     @param {EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadEventArgs} args: An instance of EVUI.Modules.HtmlLoaderController.HtmlPlaceholderLoadEventArgss describing the current load operation.*/
-    this.onBeforeLoadPlaceholderChildren = function (args)
+    this.onLoadChildren = function (args)
     {
     };
 
     /**Event that executes before the HTML returned from the server is injected into the DOM and gives the user the ability to manipulate the HTML while it is still in a document fragment.
     @param {EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadEventArgs} args: An instance of EVUI.Modules.HtmlLoaderController.HtmlPlaceholderLoadEventArgs describing the current load operation.*/
-    this.onPlaceholderInject = function (args)
+    this.onInject = function (args)
     {
 
     };
 
     /**Event that executes after the placeholder - and all of its children - have been injected into its parent and the load operation is complete.
     @param {EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadEventArgs} args: An instance of EVUI.Modules.HtmlLoaderController.HtmlPlaceholderLoadEventArgs describing the current load operation.*/
-    this.onPlaceholderLoaded = function (args)
+    this.onLoaded = function (args)
     {
 
     };
 
     /**Event that executes after all the placeholders have been loaded and injected into the DOM.
     @param {EVUI.Modules.HtmlLoader.HtmlPlaceholderLoadEventArgs} args: An instance of EVUI.Modules.HtmlLoaderController.HtmlPlaceholderLoadEventArgs describing the current load operation.*/
-    this.onAllPlaceholdersLoaded = function (args)
+    this.onComplete = function (args)
     {
 
     };
@@ -1454,6 +1468,10 @@ EVUI.Modules.HtmlLoader.HtmlLoaderControllerServices = function ()
     /**Object. An instance of Http module's HttpManager object.
     @type {EVUI.Modules.Http.HttpManager}*/
     this.httpManager = null;
+
+    /**Optional. Include to use the DomTree module to convert Html stirngs into DOM nodes.
+    @type {EVUI.Modules.DomTree.DomTreeConverter}*/
+    this.domTree = null;
 };
 
 /**Global instance of a EVUI.Modules.HtmlLoaderController.HtmlLoaderController.

--- a/src/raw/Modules/Http.js
+++ b/src/raw/Modules/Http.js
@@ -223,7 +223,8 @@ EVUI.Modules.Http.HttpManager = function ()
             var error = (entry.requestStatus === RequestStatus.Exception || entry.requestStatus === RequestStatus.Failed || entry.requestStatus === RequestStatus.TimedOut) ? entry.error : null;
 
             var httpEventArgs = new EVUI.Modules.Http.HttpEventArgs(request, xhr, error, entry.response);
-            httpEventArgs.key = args.key;
+            httpEventArgs.eventType = args.key;
+            httpEventArgs.eventName = args.name;
             httpEventArgs.stopPropagation = function () { args.stopPropagation(); };
             httpEventArgs.requestStatus = entry.requestStatus;
 
@@ -938,20 +939,24 @@ EVUI.Modules.Http.HttpEventArgs = function (request, xhr, error, response)
     @type {Number}*/
     this.requestStatus = EVUI.Modules.Http.HttpRequestStatus.NotStarted;
 
-    /**String. The unique key current step in the EventStream.
+    /**String. The full name of the event.
     @type {String}*/
-    this.key = null;
+    this.eventName = null;
 
-    /**Pauses the EventStream, preventing the next step from executing until Resume is called.*/
+    /**String. The type of event being raised.
+    @type {String}*/
+    this.eventType = null;
+
+    /**Pauses the HTTP request, preventing the next step from executing until resume is called.*/
     this.pause = function () { };
 
-    /**Resumes the EventStream, allowing it to continue to the next step.*/
+    /**Resumes the HTTP request, allowing it to continue to the next step.*/
     this.resume = function () { };
 
-    /**Cancels the EventStream and aborts the execution of the XMLHttpRequest.*/
+    /**Cancels the HTTP request and aborts the execution of the operation.*/
     this.cancel = function () { }
 
-    /**Stops the EventStream from calling any other event handlers with the same key.*/
+    /**Stops the HttpManager from calling any other event handlers with the same eventType.*/
     this.stopPropagation = function () { };
 
     /**Object. Any state value to carry between events.

--- a/src/raw/Modules/Http.js
+++ b/src/raw/Modules/Http.js
@@ -48,15 +48,17 @@ EVUI.Modules.Http.Constants = {};
  */
 EVUI.Modules.Http.Constants.Fn_HttpCallback = function (completedRequest) { }
 
-EVUI.Modules.Http.Constants.Event_OnBeforeSend = "evui.http.beforesend";
-EVUI.Modules.Http.Constants.Event_OnSuccess = "evui.http.success";
-EVUI.Modules.Http.Constants.Event_OnError = "evui.http.error";
-EVUI.Modules.Http.Constants.Event_OnComplete = "evui.http.complete";
-EVUI.Modules.Http.Constants.Event_OnAllComplete = "evui.http.complete.all";
+EVUI.Modules.Http.Constants.Event_OnBeforeSend = "beforesend";
+EVUI.Modules.Http.Constants.Event_OnSuccess = "success";
+EVUI.Modules.Http.Constants.Event_OnError = "error";
+EVUI.Modules.Http.Constants.Event_OnComplete = "complete";
+EVUI.Modules.Http.Constants.Event_OnAllComplete = "allcomplete";
 
-EVUI.Modules.Http.Constants.Job_OpenRequest = "evui.http.open";
-EVUI.Modules.Http.Constants.Job_SendRequest = "evui.http.send";
-EVUI.Modules.Http.Constants.Job_RequestComplete = "evui.http.request.complete";
+EVUI.Modules.Http.Constants.Job_OpenRequest = "job.open";
+EVUI.Modules.Http.Constants.Job_SendRequest = "job.send";
+EVUI.Modules.Http.Constants.Job_RequestComplete = "job.requestcomplete";
+
+EVUI.Modules.Http.Constants.StepPrefix = "evui.http";
 
 /**Event handler for bubbling global events attached to the HttpManager.
 @param {EVUI.Modules.Http.HttpEventArgs} httpEventArgs The event arguments for the event.*/
@@ -263,7 +265,7 @@ EVUI.Modules.Http.HttpManager = function ()
         //set up local on before send event
         es.addStep({
             key: EVUI.Modules.Http.Constants.Event_OnBeforeSend,
-            name: "onBeforeSend",
+            name: EVUI.Modules.Http.Constants.StepPrefix + "." + EVUI.Modules.Http.Constants.Event_OnBeforeSend,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (httpEventArgs)
             {
@@ -277,7 +279,7 @@ EVUI.Modules.Http.HttpManager = function ()
         //set up the global on before send event
         es.addStep({
             key: EVUI.Modules.Http.Constants.Event_OnBeforeSend,
-            name: "onBeforeSend",
+            name: EVUI.Modules.Http.Constants.StepPrefix + "." + EVUI.Modules.Http.Constants.Event_OnBeforeSend,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (httpEventArgs)
             {
@@ -291,7 +293,7 @@ EVUI.Modules.Http.HttpManager = function ()
         //set up the job that opens and sets all the settings for the XMLHttpRequest
         es.addStep({
             key: EVUI.Modules.Http.Constants.Job_OpenRequest,
-            name: "openRequest",
+            name: EVUI.Modules.Http.Constants.StepPrefix + "." + EVUI.Modules.Http.Constants.Job_OpenRequest,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             /**@param {EVUI.Resources.EventStreamJobArgs} jobArgs*/
             handler: function (jobArgs)
@@ -370,7 +372,7 @@ EVUI.Modules.Http.HttpManager = function ()
         //set up the step where we launch the request
         es.addStep({
             key: EVUI.Modules.Http.Constants.Job_SendRequest,
-            name: "sendRequest",
+            name: EVUI.Modules.Http.Constants.StepPrefix + "." + EVUI.Modules.Http.Constants.Job_SendRequest,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
             {
@@ -455,7 +457,7 @@ EVUI.Modules.Http.HttpManager = function ()
         //local event for success
         es.addStep({
             key: EVUI.Modules.Http.Constants.Event_OnSuccess,
-            name: "onSuccess",
+            name: EVUI.Modules.Http.Constants.StepPrefix + "." + EVUI.Modules.Http.Constants.Event_OnSuccess,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (httpEventArgs)
             {
@@ -469,7 +471,7 @@ EVUI.Modules.Http.HttpManager = function ()
         //global event for success
         es.addStep({
             key: EVUI.Modules.Http.Constants.Event_OnSuccess,
-            name: "onSuccess",
+            name: EVUI.Modules.Http.Constants.StepPrefix + "." + EVUI.Modules.Http.Constants.Event_OnSuccess,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (httpEventArgs)
             {
@@ -483,7 +485,7 @@ EVUI.Modules.Http.HttpManager = function ()
         //this "job" skips over the error handlers and goes straight to the on complete handlers
         es.addStep({
             key: EVUI.Modules.Http.Constants.Job_RequestComplete,
-            name: "requestComplete",
+            name: EVUI.Modules.Http.Constants.StepPrefix + "." + EVUI.Modules.Http.Constants.Job_RequestComplete,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
             {
@@ -495,7 +497,7 @@ EVUI.Modules.Http.HttpManager = function ()
         //local error handler
         es.addStep({
             key: EVUI.Modules.Http.Constants.Event_OnError,
-            name: "onError",
+            name: EVUI.Modules.Http.Constants.StepPrefix + "." + EVUI.Modules.Http.Constants.Event_OnError,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (httpEventArgs)
             {
@@ -509,7 +511,7 @@ EVUI.Modules.Http.HttpManager = function ()
         //global error handler
         es.addStep({
             key: EVUI.Modules.Http.Constants.Event_OnError,
-            name: "OnError",
+            name: EVUI.Modules.Http.Constants.StepPrefix + "." + EVUI.Modules.Http.Constants.Event_OnError,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (httpEventArgs)
             {
@@ -523,7 +525,7 @@ EVUI.Modules.Http.HttpManager = function ()
         //local complete handler
         es.addStep({
             key: EVUI.Modules.Http.Constants.Event_OnComplete,
-            name: "OnComplete",
+            name: EVUI.Modules.Http.Constants.StepPrefix + "." + EVUI.Modules.Http.Constants.Event_OnComplete,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (httpEventArgs)
             {
@@ -537,7 +539,7 @@ EVUI.Modules.Http.HttpManager = function ()
         //global complete handler
         es.addStep({
             key: EVUI.Modules.Http.Constants.Event_OnComplete,
-            name: "OnComplete",
+            name: EVUI.Modules.Http.Constants.StepPrefix + "." + EVUI.Modules.Http.Constants.Event_OnComplete,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (httpEventArgs)
             {
@@ -549,8 +551,8 @@ EVUI.Modules.Http.HttpManager = function ()
         });
 
         es.addStep({
-            key: EVUI.Modules.Http.Constants.Event_OnComplete,
-            name: "onAllComplete",
+            key: EVUI.Modules.Http.Constants.Event_OnAllComplete,
+            name: EVUI.Modules.Http.Constants.StepPrefix + "." + EVUI.Modules.Http.Constants.Event_OnAllComplete,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function ()
             {

--- a/src/raw/Modules/IFrames.js
+++ b/src/raw/Modules/IFrames.js
@@ -62,19 +62,25 @@ EVUI.Modules.IFrames.Constants.PlaceholderIFrameContextID = "evui.iframe.placeho
 
 /**Event key for the event that fires when a message arrives in this Window.
 @type {String}*/
-EVUI.Modules.IFrames.Constants.Event_OnMessage = "evui.iframes.onmessage";
+EVUI.Modules.IFrames.Constants.Event_OnMessage = "message";
 
 /**Event key for the event that fires when a message arrives in this Window and is handled by a named IFrameMessageListener.
 @type {String}*/
-EVUI.Modules.IFrames.Constants.Event_OnHandler = "evui.iframes.onhandler";
+EVUI.Modules.IFrames.Constants.Event_OnHandle = "handle";
 
 /**Event key for the event that fires when a message arrives in this Window in response to an ask operation.
 @type {String}*/
-EVUI.Modules.IFrames.Constants.Event_OnAsk = "evui.iframes.onask"
+EVUI.Modules.IFrames.Constants.Event_OnAsk = "ask"
 
 /**Event key for the event that fires when a message is sent from this Window to another.
 @type {String}*/
-EVUI.Modules.IFrames.Constants.Event_OnSend = "evui.iframes.onsend";
+EVUI.Modules.IFrames.Constants.Event_OnSend = "send";
+
+EVUI.Modules.IFrames.Constants.Job_Send = "job.send";
+
+EVUI.Modules.IFrames.Constants.Job_Ask = "job.ask";
+
+EVUI.Modules.IFrames.Constants.StepPrefix = "evui.iframes";
 
 Object.freeze(EVUI.Modules.IFrames.Constants);
 
@@ -763,7 +769,7 @@ EVUI.Modules.IFrames.IFrameManager = function ()
             if (entry == null) //not a managed iframe
             {
                 var incomingIFrame = getIFrameFromContentWindow(messageEvent.source); //go find the iframe element on the page that sent the message
-                if (incomingIFrame == null) return; //cloudn't find it, bail
+                if (incomingIFrame == null) return; //couldn't find it, bail
 
                 if (EVUI.Modules.Core.Utils.isSettingTrue("autoAddIncomingIFrames") === true) //if we're auto-adding iframes, register the new iframe with the manager.
                 {
@@ -813,6 +819,7 @@ EVUI.Modules.IFrames.IFrameManager = function ()
             es.addStep({
                 type: EVUI.Modules.EventStream.EventStreamStepType.Event,
                 key: EVUI.Modules.IFrames.Constants.Event_OnAsk,
+                name: EVUI.Modules.IFrames.Constants.StepPrefix + "." + EVUI.Modules.IFrames.Constants.Event_OnAsk,
                 handler: function (eventArgs)
                 {
                     return askSession.askCallback(eventArgs.message.data);
@@ -824,11 +831,13 @@ EVUI.Modules.IFrames.IFrameManager = function ()
             es.addStep({
                 type: EVUI.Modules.EventStream.EventStreamStepType.Event,
                 key: EVUI.Modules.IFrames.Constants.Event_OnMessage,
+
+                name: EVUI.Modules.IFrames.Constants.StepPrefix + "." + EVUI.Modules.IFrames.Constants.Event_OnMessage,
                 handler: function (eventArgs)
                 {
                     if (typeof iframeEntry.handle.onMessage === "function")
                     {
-                        return iframeEntry.handle.onMessage(eventArgs);
+                        return iframeEntry.handle.onMessage.call(this, eventArgs);
                     }
                 }
             });
@@ -836,6 +845,7 @@ EVUI.Modules.IFrames.IFrameManager = function ()
             es.addStep({
                 type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
                 key: EVUI.Modules.IFrames.Constants.Event_OnMessage,
+                name: EVUI.Modules.IFrames.Constants.StepPrefix + "." + EVUI.Modules.IFrames.Constants.Event_OnMessage,
                 handler: function (eventArgs)
                 {
                     if (typeof _self.onMessage === "function")
@@ -847,7 +857,8 @@ EVUI.Modules.IFrames.IFrameManager = function ()
 
             es.addStep({
                 type: EVUI.Modules.EventStream.EventStreamStepType.Event,
-                key: EVUI.Modules.IFrames.Constants.Event_OnHandler,
+                key: EVUI.Modules.IFrames.Constants.Event_OnHandle,
+                name: EVUI.Modules.IFrames.Constants.StepPrefix + "." + EVUI.Modules.IFrames.Constants.Event_OnHandle,
                 handler: function (eventArgs)
                 {
                     var handler = getMessageHandler(messageSession.entry.handle, messageSession.messageWapper.metadata.messageCode);
@@ -874,6 +885,7 @@ EVUI.Modules.IFrames.IFrameManager = function ()
         es.addStep({
             key: EVUI.Modules.IFrames.Constants.Event_OnSend,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
+            name: EVUI.Modules.IFrames.Constants.StepPrefix + "." + EVUI.Modules.IFrames.Constants.Event_OnSend,
             handler: function (eventArgs)
             {
                 if (typeof messageSession.entry.handle.onSend === "function")
@@ -886,6 +898,7 @@ EVUI.Modules.IFrames.IFrameManager = function ()
         es.addStep({
             key: EVUI.Modules.IFrames.Constants.Event_OnSend,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
+            name: EVUI.Modules.IFrames.Constants.StepPrefix + "." + EVUI.Modules.IFrames.Constants.Event_OnSend,
             handler: function (eventArgs)
             {
                 if (typeof _self.onSend === "function")
@@ -896,8 +909,9 @@ EVUI.Modules.IFrames.IFrameManager = function ()
         });
 
         es.addStep({
-            key: "evui.iframes.send",
+            key: EVUI.Modules.IFrames.Constants.Job_Send,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
+            name: EVUI.Modules.IFrames.Constants.StepPrefix + "." + EVUI.Modules.IFrames.Constants.Job_Send,
             handler: function (jobArgs)
             {
                 var target = null;
@@ -930,8 +944,9 @@ EVUI.Modules.IFrames.IFrameManager = function ()
             messageSession.entry.messageSessions.push(messageSession);
 
             es.addStep({
-                key: "evui.iframes.asktimeout",
+                key: EVUI.Modules.IFrames.Constants.Job_Ask,
                 type: EVUI.Modules.EventStream.EventStreamStepType.Job,
+                name: EVUI.Modules.IFrames.Constants.StepPrefix + "." + EVUI.Modules.IFrames.Constants.Job_Ask,
                 handler: function (jobArgs)
                 {
                     var finish = function (value)
@@ -1009,7 +1024,8 @@ EVUI.Modules.IFrames.IFrameManager = function ()
             var iframeArgs = new EVUI.Modules.IFrames.IFrameEventArgs(messageSession.entry.iFrame, message);
             iframeArgs.cancel = eventArgs.cancel;
             iframeArgs.context = es.eventState;
-            iframeArgs.key = eventArgs.key;
+            iframeArgs.eventType = eventArgs.key;
+            iframeArgs.eventName = eventArgs.name;
             iframeArgs.pause = eventArgs.pause;
             iframeArgs.resume = eventArgs.resume;
             iframeArgs.stopPropagation = eventArgs.stopPropagation;
@@ -1411,10 +1427,6 @@ EVUI.Modules.IFrames.IFrameEventArgs = function (iframe, message)
     var _iframe = iframe;
     var _message = message;
 
-    /**String. The unique key of this event.
-    @type {String}*/
-    this.key = null;
-
     /**Object. The window that sent the message.
     @type {EVUI.Modules.IFrames.IFrame}*/
     this.sendingIFrame = null;
@@ -1433,12 +1445,28 @@ EVUI.Modules.IFrames.IFrameEventArgs = function (iframe, message)
         configurable: false
     });
 
-    /** */
+    /**String. The full name of the event.
+    @type {String}*/
+    this.eventName = null;
+
+    /**String. The type of event being raised.
+    @type {String}*/
+    this.eventType = null;
+
+    /**Pauses the IFrame's action, preventing the next step from executing until resume is called.*/
     this.pause = function () { };
+
+    /**Resumes the IFrame's action, allowing it to continue to the next step.*/
     this.resume = function () { };
-    this.cancel = function () { };
+
+    /**Cancels the IFrame's action and aborts the execution of the operation.*/
+    this.cancel = function () { }
+
+    /**Stops the IFrame from calling any other event handlers with the same eventType.*/
     this.stopPropagation = function () { };
-    this.respond = function (data, messageCodeOrArgs, senderName) { };
+
+    /**Object. Any state value to carry between events.
+    @type {Object}*/
     this.context = {};
 };
 

--- a/src/raw/Modules/Modals.js
+++ b/src/raw/Modules/Modals.js
@@ -500,7 +500,8 @@ EVUI.Modules.Modals.ModalManager = function (services)
 
         var modalEventArgs = new EVUI.Modules.Modals.ModalEventArgs(argsPackage, args);
         modalEventArgs.cancel = paneEventArgs.cancel;
-        modalEventArgs.key = paneEventArgs.key;
+        modalEventArgs.eventType = paneEventArgs.eventType;
+        modalEventArgs.eventName = paneEventArgs.eventName;
         modalEventArgs.pause = paneEventArgs.pause;
         modalEventArgs.resume = paneEventArgs.resume;
         modalEventArgs.stopPropagation = paneEventArgs.stopPropagation;
@@ -1050,20 +1051,24 @@ EVUI.Modules.Modals.ModalEventArgs = function (argsPackage, currentArgs)
             enumerable: true
         });
 
-    /**String. The unique key current step in the EventStream.
+    /**String. The full name of the event.
     @type {String}*/
-    this.key = null;
+    this.eventName = null;
 
-    /**Function. Pauses the EventStream, preventing the next step from executing until resume is called.*/
+    /**String. The type of event being raised.
+    @type {String}*/
+    this.eventType = null;
+
+    /**Pauses the Modal's action, preventing the next step from executing until resume is called.*/
     this.pause = function () { };
 
-    /**Function. Resumes the EventStream, allowing it to continue to the next step.*/
+    /**Resumes the Modal's action, allowing it to continue to the next step.*/
     this.resume = function () { };
 
-    /**Function. Cancels the EventStream and aborts the execution of the Modal operation.*/
+    /**Cancels the Modal's action and aborts the execution of the operation.*/
     this.cancel = function () { }
 
-    /**Function. Stops the EventStream from calling any other event handlers with the same key.*/
+    /**Stops the Modal from calling any other event handlers with the same eventType.*/
     this.stopPropagation = function () { };
 
     /**Object. The position of the Modal that has been calculated in using the currentShowSettings.
@@ -1076,7 +1081,7 @@ EVUI.Modules.Modals.ModalEventArgs = function (argsPackage, currentArgs)
             enumerable: true
         });
 
-    /**Object. The PaneHide/Show/Load/Unload Arguments being used for the operation.
+    /**Object. The ModalHide/Show/Load/Unload Arguments being used for the operation.
     @type {EVUI.Modules.Modals.ModalShowArgs|EVUI.Modules.Modals.ModalHideArgs|EVUI.Modules.Modals.ModalLoadArgs|EVUI.Modules.Modals.ModalUnloadArgs}*/
     this.currentActionArgs = null;
     Object.defineProperty(this, "currentActionArgs", {

--- a/src/raw/Modules/Modals.js
+++ b/src/raw/Modules/Modals.js
@@ -109,7 +109,7 @@ EVUI.Modules.Modals.Constants.Attribute_Backdrop = "evui-m-show-backdrop";
 EVUI.Modules.Modals.Constants.Default_ObjectName = "Modal";
 EVUI.Modules.Modals.Constants.Default_ManagerName = "ModalManager";
 EVUI.Modules.Modals.Constants.Default_CssPrefix = "evui-m";
-EVUI.Modules.Modals.Constants.Default_EventNamePrefix = "evui.m";
+EVUI.Modules.Modals.Constants.Default_StepPrefix = "evui.m";
 EVUI.Modules.Modals.Constants.Default_AttributePrefix = "evui-m";
 
 Object.freeze(EVUI.Modules.Modals.Constants);
@@ -742,7 +742,7 @@ EVUI.Modules.Modals.ModalManager = function (services)
     _settings.attributePrefix = EVUI.Modules.Modals.Constants.Default_AttributePrefix;
     _settings.cssPrefix = EVUI.Modules.Modals.Constants.Default_CssPrefix;
     _settings.cssSheetName = EVUI.Modules.Styles.Constants.DefaultStyleSheetName;
-    _settings.eventNamePrefix = EVUI.Modules.Modals.Constants.Default_EventNamePrefix;
+    _settings.stepPrefix = EVUI.Modules.Modals.Constants.Default_StepPrefix;
     _settings.managerName = EVUI.Modules.Modals.Constants.Default_ManagerName;
     _settings.objectName = EVUI.Modules.Modals.Constants.Default_ObjectName;
     _settings.makeOrExtendObject = makeOrExtendObject;

--- a/src/raw/Modules/Panes.js
+++ b/src/raw/Modules/Panes.js
@@ -113,14 +113,14 @@ EVUI.Modules.Panes.Constants.Job_Preload = "job.preload";
 EVUI.Modules.Panes.Constants.Job_Load = "job.load";
 EVUI.Modules.Panes.Constants.Job_Initialize = "job.init";
 EVUI.Modules.Panes.Constants.Job_Hide = "job.hide";
-EVUI.Modules.Panes.Constants.Job_InitialPosition = "job.initial.position";
-EVUI.Modules.Panes.Constants.Job_FinalPosition = "job.final.position";
+EVUI.Modules.Panes.Constants.Job_InitialPosition = "job.initialposition";
+EVUI.Modules.Panes.Constants.Job_FinalPosition = "job.finalposition";
 EVUI.Modules.Panes.Constants.Job_Unload = "job.unload";
 
 EVUI.Modules.Panes.Constants.Default_ObjectName = "Pane";
 EVUI.Modules.Panes.Constants.Default_ManagerName = "PaneManager";
 EVUI.Modules.Panes.Constants.Default_CssPrefix = "evui-pane";
-EVUI.Modules.Panes.Constants.Default_EventNamePrefix = "evui.pane";
+EVUI.Modules.Panes.Constants.Default_StepPrefix = "evui.pane";
 EVUI.Modules.Panes.Constants.Default_AttributePrefix = "evui-pane";
 
 /**The global Z-index reference for all objects that use the pane manager to determine their z-index.
@@ -2308,7 +2308,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         var skipLoad = false;
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_Preload,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Job_Preload,
             key: EVUI.Modules.Panes.Constants.Job_Preload,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
@@ -2326,7 +2326,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
 
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnLoad,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnLoad,
             key: EVUI.Modules.Panes.Constants.Event_OnLoad,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
@@ -2341,7 +2341,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnLoad,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnLoad,
             key: EVUI.Modules.Panes.Constants.Event_OnLoad,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
@@ -2356,7 +2356,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_Load,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Job_Load,
             key: EVUI.Modules.Panes.Constants.Job_Load,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
@@ -2397,7 +2397,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnLoaded,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnLoaded,
             key: EVUI.Modules.Panes.Constants.Event_OnLoaded,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
@@ -2412,7 +2412,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnLoaded,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnLoaded,
             key: EVUI.Modules.Panes.Constants.Event_OnLoaded,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
@@ -2434,7 +2434,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
     var addInitSteps = function (eventStream, opSession)
     {
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnInitialize,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnInitialize,
             key: EVUI.Modules.Panes.Constants.Event_OnInitialize,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
@@ -2450,7 +2450,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnInitialize,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnInitialize,
             key: EVUI.Modules.Panes.Constants.Event_OnInitialize,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
@@ -2465,7 +2465,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_Initialize,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Job_Initialize,
             key: EVUI.Modules.Panes.Constants.Job_Initialize,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
@@ -2483,7 +2483,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
     var addShowSteps = function (eventStream, opSession)
     {
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnShow,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnShow,
             key: EVUI.Modules.Panes.Constants.Event_OnShow,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
@@ -2498,7 +2498,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnShow,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnShow,
             key: EVUI.Modules.Panes.Constants.Event_OnShow,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
@@ -2513,7 +2513,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         addPositionSteps(eventStream, opSession);
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnShown,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnShown,
             key: EVUI.Modules.Panes.Constants.Event_OnShown,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
@@ -2526,7 +2526,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnShown,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnShown,
             key: EVUI.Modules.Panes.Constants.Event_OnShown,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
@@ -2548,7 +2548,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         var skip = false;
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnHide,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnHide,
             key: EVUI.Modules.Panes.Constants.Event_OnHide,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
@@ -2568,7 +2568,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnHide,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnHide,
             key: EVUI.Modules.Panes.Constants.Event_OnHide,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
@@ -2583,7 +2583,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_Hide,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Job_Hide,
             key: EVUI.Modules.Panes.Constants.Job_Hide,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
@@ -2616,7 +2616,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnHidden,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnHidden,
             key: EVUI.Modules.Panes.Constants.Event_OnHidden,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
@@ -2631,7 +2631,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnHidden,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnHidden,
             key: EVUI.Modules.Panes.Constants.Event_OnHidden,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
@@ -2656,7 +2656,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         var showArgsObserver = null;
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_InitialPosition,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Job_InitialPosition,
             key: EVUI.Modules.Panes.Constants.Job_InitialPosition,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
@@ -2673,7 +2673,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnPosition,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnPosition,
             key: EVUI.Modules.Panes.Constants.Event_OnPosition,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
@@ -2686,7 +2686,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnPosition,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnPosition,
             key: EVUI.Modules.Panes.Constants.Event_OnPosition,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
@@ -2699,7 +2699,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_FinalPosition,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Job_FinalPosition,
             key: EVUI.Modules.Panes.Constants.Job_FinalPosition,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
@@ -2772,7 +2772,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
     {
         eventStream.addStep({
 
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_Complete,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Job_Complete,
             key: EVUI.Modules.Panes.Constants.Job_Complete,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (args)
@@ -2802,7 +2802,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         var skip = false;
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnUnload,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnUnload,
             key: EVUI.Modules.Panes.Constants.Event_OnUnload,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
@@ -2829,7 +2829,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnUnload,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnUnload,
             key: EVUI.Modules.Panes.Constants.Event_OnUnload,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
@@ -2844,7 +2844,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_Unload,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Job_Unload,
             key: EVUI.Modules.Panes.Constants.Job_Unload,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
@@ -2867,7 +2867,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnUnloaded,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnUnloaded,
             key: EVUI.Modules.Panes.Constants.Event_OnUnloaded,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
@@ -2882,7 +2882,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnUnloaded,
+            name: _settings.stepPrefix + "." + EVUI.Modules.Panes.Constants.Event_OnUnloaded,
             key: EVUI.Modules.Panes.Constants.Event_OnUnloaded,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
@@ -6152,7 +6152,7 @@ EVUI.Modules.Panes.PaneManagerSettings = function ()
 
     /**String. The prefix for all the events that the PaneManager will raise.
     @type {String}*/
-    this.eventNamePrefix = EVUI.Modules.Panes.Constants.Default_EventNamePrefix;
+    this.stepPrefix = EVUI.Modules.Panes.Constants.Default_StepPrefix;
 
     /**String. The prefix for all the attributes used by the PaneManager.
     @type {String}*/

--- a/src/raw/Modules/Panes.js
+++ b/src/raw/Modules/Panes.js
@@ -95,20 +95,27 @@ For example, "absolutePosition.x: 123; absolutePosition.y: 456" would set the ab
 As another example, "relativePosition.element: '#myElement'; clipSettings.clipBounds.top: 123; clipSettings.clipBounds.left: 456; clipSettings.mode:'shift';" would position the Pane around the element that matches the #myElement selector and would be */
 EVUI.Modules.Panes.Constants.Attribute_ShowSettings = "evui-pane-show-settings";
 
-EVUI.Modules.Panes.Constants.Event_OnShow = "evui.pane.onshow";
-EVUI.Modules.Panes.Constants.Event_OnHide = "evui.pane.onhide";
-EVUI.Modules.Panes.Constants.Event_OnUnload = "evui.pane.onunload";
-EVUI.Modules.Panes.Constants.Event_OnLoad = "evui.pane.onload";
+EVUI.Modules.Panes.Constants.Event_OnShow = "show";
+EVUI.Modules.Panes.Constants.Event_OnHide = "hide";
+EVUI.Modules.Panes.Constants.Event_OnUnload = "unload";
+EVUI.Modules.Panes.Constants.Event_OnLoad = "load";
 
-EVUI.Modules.Panes.Constants.Event_OnShown = "evui.pane.onshown";
-EVUI.Modules.Panes.Constants.Event_OnOnHidden = "evui.pane.onhidden";
-EVUI.Modules.Panes.Constants.Event_OnLoaded = "evui.pane.onloaded";
-EVUI.Modules.Panes.Constants.Event_OnUnloaded = "evui.pane.onunloaded";
+EVUI.Modules.Panes.Constants.Event_OnShown = "shown";
+EVUI.Modules.Panes.Constants.Event_OnHidden = "hidden";
+EVUI.Modules.Panes.Constants.Event_OnLoaded = "loaded";
+EVUI.Modules.Panes.Constants.Event_OnUnloaded = "unloaded";
 
-EVUI.Modules.Panes.Constants.Event_OnInitialize = "evui.pane.oninit";
-EVUI.Modules.Panes.Constants.Event_OnPosition = "evui.pane.onposition";
+EVUI.Modules.Panes.Constants.Event_OnInitialize = "init";
+EVUI.Modules.Panes.Constants.Event_OnPosition = "position";
 
-EVUI.Modules.Panes.Constants.Job_OnComplete = "evui.pane.oncomplete";
+EVUI.Modules.Panes.Constants.Job_Complete = "job.complete";
+EVUI.Modules.Panes.Constants.Job_Preload = "job.preload";
+EVUI.Modules.Panes.Constants.Job_Load = "job.load";
+EVUI.Modules.Panes.Constants.Job_Initialize = "job.init";
+EVUI.Modules.Panes.Constants.Job_Hide = "job.hide";
+EVUI.Modules.Panes.Constants.Job_InitialPosition = "job.initial.position";
+EVUI.Modules.Panes.Constants.Job_FinalPosition = "job.final.position";
+EVUI.Modules.Panes.Constants.Job_Unload = "job.unload";
 
 EVUI.Modules.Panes.Constants.Default_ObjectName = "Pane";
 EVUI.Modules.Panes.Constants.Default_ManagerName = "PaneManager";
@@ -2092,11 +2099,11 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         }
 
         //then cancel the normal step that calls the callback for the previous event stream.
-        var completeStep = opSession.entry.link.eventStream.getStep(_settings.eventNamePrefix + ".oncomplete");
+        var completeStep = opSession.entry.link.eventStream.getStep(EVUI.Modules.Panes.Constants.Job_OnComplete);
         completeStep.handler = function (jobArgs) { jobArgs.resolve(); }
 
         //then get the same step, but in the new event stream and overwrite its handler to call BOTH callback stacks. We must the last one first and the first one last - this  because of some kind of race condition that predictably inverts the sequence, so we call them backwards 
-        var realCompleteStep = eventStream.getStep(_settings.eventNamePrefix + ".oncomplete");
+        var realCompleteStep = eventStream.getStep(EVUI.Modules.Panes.Constants.Job_OnComplete);
         realCompleteStep.handler = function (jobArgs)
         {
             callCallbackStack(opSession.entry.link, opSession.action, true, function ()
@@ -2250,12 +2257,12 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
 
         eventStream.onCancel = function ()
         {
-            eventStream.seek(_settings.eventNamePrefix + ".oncomplete");
+            eventStream.seek(EVUI.Modules.Panes.Constants.Job_OnComplete);
         };
 
         eventStream.onError = function (args, error)
         {
-            eventStream.seek(_settings.eventNamePrefix + ".oncomplete");
+            eventStream.seek(EVUI.Modules.Panes.Constants.Job_OnComplete);
         }
     };
 
@@ -2301,8 +2308,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         var skipLoad = false;
 
         eventStream.addStep({
-            name: "preload",
-            key: _settings.eventNamePrefix + ".preload",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_Preload,
+            key: EVUI.Modules.Panes.Constants.Job_Preload,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
             {
@@ -2319,8 +2326,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
 
 
         eventStream.addStep({
-            name: "onLoad",
-            key: _settings.eventNamePrefix + ".onload",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnLoad,
+            key: EVUI.Modules.Panes.Constants.Event_OnLoad,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -2334,8 +2341,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "onLoad",
-            key: _settings.eventNamePrefix + ".onload",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnLoad,
+            key: EVUI.Modules.Panes.Constants.Event_OnLoad,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {
@@ -2349,8 +2356,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "load",
-            key: _settings.eventNamePrefix + ".load",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_Load,
+            key: EVUI.Modules.Panes.Constants.Job_Load,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
             {
@@ -2390,8 +2397,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "onLoaded",
-            key: _settings.eventNamePrefix + ".onloaded",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnLoaded,
+            key: EVUI.Modules.Panes.Constants.Event_OnLoaded,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -2405,8 +2412,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "onLoaded",
-            key: _settings.eventNamePrefix + ".onloaded",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnLoaded,
+            key: EVUI.Modules.Panes.Constants.Event_OnLoaded,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {
@@ -2427,8 +2434,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
     var addInitSteps = function (eventStream, opSession)
     {
         eventStream.addStep({
-            name: "onInitialize",
-            key: _settings.eventNamePrefix + ".oninit",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnInitialize,
+            key: EVUI.Modules.Panes.Constants.Event_OnInitialize,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -2443,8 +2450,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "onInitialize",
-            key: _settings.eventNamePrefix + ".oninit",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnInitialize,
+            key: EVUI.Modules.Panes.Constants.Event_OnInitialize,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {
@@ -2458,8 +2465,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "initialize",
-            key: _settings.eventNamePrefix + ".load",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_Initialize,
+            key: EVUI.Modules.Panes.Constants.Job_Initialize,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
             {
@@ -2476,8 +2483,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
     var addShowSteps = function (eventStream, opSession)
     {
         eventStream.addStep({
-            name: "onShow",
-            key: _settings.eventNamePrefix + ".onshow",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnShow,
+            key: EVUI.Modules.Panes.Constants.Event_OnShow,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -2491,8 +2498,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "onShow",
-            key: _settings.eventNamePrefix + ".onshow",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnShow,
+            key: EVUI.Modules.Panes.Constants.Event_OnShow,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {
@@ -2506,8 +2513,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         addPositionSteps(eventStream, opSession);
 
         eventStream.addStep({
-            name: "onShown",
-            key: _settings.eventNamePrefix + ".onshown",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnShown,
+            key: EVUI.Modules.Panes.Constants.Event_OnShown,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -2519,8 +2526,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "onShown",
-            key: _settings.eventNamePrefix + ".onshown",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnShown,
+            key: EVUI.Modules.Panes.Constants.Event_OnShown,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {
@@ -2541,8 +2548,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         var skip = false;
 
         eventStream.addStep({
-            name: "onHide",
-            key: _settings.eventNamePrefix + ".onHide",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnHide,
+            key: EVUI.Modules.Panes.Constants.Event_OnHide,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -2561,8 +2568,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "onHide",
-            key: _settings.eventNamePrefix + ".onHide",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnHide,
+            key: EVUI.Modules.Panes.Constants.Event_OnHide,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {
@@ -2576,8 +2583,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "hide",
-            key: _settings.eventNamePrefix + "hide",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_Hide,
+            key: EVUI.Modules.Panes.Constants.Job_Hide,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
             {
@@ -2609,8 +2616,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "ohHidden",
-            key: _settings.eventNamePrefix + ".onhidden",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnHidden,
+            key: EVUI.Modules.Panes.Constants.Event_OnHidden,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -2624,8 +2631,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "ohHidden",
-            key: _settings.eventNamePrefix + ".onhidden",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnHidden,
+            key: EVUI.Modules.Panes.Constants.Event_OnHidden,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {
@@ -2649,8 +2656,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         var showArgsObserver = null;
 
         eventStream.addStep({
-            name: "initialPosition",
-            key: _settings.eventNamePrefix + ".initialposition",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_InitialPosition,
+            key: EVUI.Modules.Panes.Constants.Job_InitialPosition,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
             {
@@ -2666,8 +2673,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "onPosition",
-            key: _settings.eventNamePrefix + ".onposition",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnPosition,
+            key: EVUI.Modules.Panes.Constants.Event_OnPosition,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -2679,8 +2686,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "onPosition",
-            key: _settings.eventNamePrefix + ".onposition",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnPosition,
+            key: EVUI.Modules.Panes.Constants.Event_OnPosition,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {
@@ -2692,8 +2699,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "finalPosition",
-            key: _settings.eventNamePrefix + ".finalposition",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_FinalPosition,
+            key: EVUI.Modules.Panes.Constants.Job_FinalPosition,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
             {
@@ -2765,8 +2772,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
     {
         eventStream.addStep({
 
-            name: "OnComplete",
-            key: _settings.eventNamePrefix + ".oncomplete",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_Complete,
+            key: EVUI.Modules.Panes.Constants.Job_Complete,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (args)
             {
@@ -2795,8 +2802,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         var skip = false;
 
         eventStream.addStep({
-            name: "onUnload",
-            key: _settings.eventNamePrefix + ".onunload",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnUnload,
+            key: EVUI.Modules.Panes.Constants.Event_OnUnload,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -2822,8 +2829,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "onUnload",
-            key: _settings.eventNamePrefix + ".onunload",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnUnload,
+            key: EVUI.Modules.Panes.Constants.Event_OnUnload,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {
@@ -2837,8 +2844,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "unload",
-            key: _settings.eventNamePrefix + ".unload",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Job_Unload,
+            key: EVUI.Modules.Panes.Constants.Job_Unload,
             type: EVUI.Modules.EventStream.EventStreamStepType.Job,
             handler: function (jobArgs)
             {
@@ -2860,8 +2867,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "onUnloaded",
-            key: _settings.eventNamePrefix + ".onunloaded",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnUnloaded,
+            key: EVUI.Modules.Panes.Constants.Event_OnUnloaded,
             type: EVUI.Modules.EventStream.EventStreamStepType.Event,
             handler: function (eventArgs)
             {
@@ -2875,8 +2882,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
         });
 
         eventStream.addStep({
-            name: "onUnloaded",
-            key: _settings.eventNamePrefix + ".onUnloaded",
+            name: _settings.eventNamePrefix + "." + EVUI.Modules.Panes.Constants.Event_OnUnloaded,
+            key: EVUI.Modules.Panes.Constants.Event_OnUnloaded,
             type: EVUI.Modules.EventStream.EventStreamStepType.GlobalEvent,
             handler: function (eventArgs)
             {

--- a/src/raw/Modules/Panes.js
+++ b/src/raw/Modules/Panes.js
@@ -2236,7 +2236,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerSettings)
 
             var paneArgs = new EVUI.Modules.Panes.PaneEventArgs(opSession.entry, curArgs);
             paneArgs.cancel = eventStreamArgs.cancel;
-            paneArgs.key = eventStreamArgs.key;
+            paneArgs.eventType = eventStreamArgs.key;
+            paneArgs.eventName = eventStreamArgs.name;
             paneArgs.pause = eventStreamArgs.pause;
             paneArgs.resume = eventStreamArgs.resume;
             paneArgs.stopPropagation = eventStreamArgs.stopPropagation;
@@ -7526,20 +7527,24 @@ EVUI.Modules.Panes.PaneEventArgs = function (entry, currentArgs)
         enumerable: true
     });
 
-    /**String. The unique key current step in the EventStream.
+    /**String. The full name of the event.
     @type {String}*/
-    this.key = null;
+    this.eventName = null;
 
-    /**Function. Pauses the EventStream, preventing the next step from executing until resume is called.*/
+    /**String. The type of event being raised.
+    @type {String}*/
+    this.eventType = null;
+
+    /**Pauses the Pane's action, preventing the next step from executing until resume is called.*/
     this.pause = function () { };
 
-    /**Function. Resumes the EventStream, allowing it to continue to the next step.*/
+    /**Resumes the Pane's action, allowing it to continue to the next step.*/
     this.resume = function () { };
 
-    /**Function. Cancels the EventStream and aborts the execution of the Pane operation.*/
+    /**Cancels the Pane's action and aborts the execution of the operation.*/
     this.cancel = function () { }
 
-    /**Function. Stops the EventStream from calling any other event handlers with the same key.*/
+    /**Stops the Pane from calling any other event handlers with the same eventType.*/
     this.stopPropagation = function () { };
 
     /**Object. The position of the Pane that has been calculated in using the currentShowSettings.

--- a/src/raw/Modules/PopIns.js
+++ b/src/raw/Modules/PopIns.js
@@ -115,9 +115,9 @@ EVUI.Modules.PopIns.Constants.Attribute_BottomAnchor = "evui-pop-anchor-bottom";
 
 EVUI.Modules.PopIns.Constants.Default_ObjectName = "PopIn";
 EVUI.Modules.PopIns.Constants.Default_ManagerName = "PopInManager";
-EVUI.Modules.PopIns.Constants.Default_CssPrefix = "evui-pop";
-EVUI.Modules.PopIns.Constants.Default_EventNamePrefix = "evui.pop";
-EVUI.Modules.PopIns.Constants.Default_AttributePrefix = "evui-pop";
+EVUI.Modules.PopIns.Constants.Default_CssPrefix = "evui-popin";
+EVUI.Modules.PopIns.Constants.Default_StepPrefix = "evui.popin";
+EVUI.Modules.PopIns.Constants.Default_AttributePrefix = "evui-popin";
 
 Object.freeze(EVUI.Modules.PopIns.Constants);
 
@@ -809,7 +809,7 @@ EVUI.Modules.PopIns.PopInManager = function (services)
     _settings.attributePrefix = EVUI.Modules.PopIns.Constants.Default_AttributePrefix;
     _settings.cssPrefix = EVUI.Modules.PopIns.Constants.Default_CssPrefix;
     _settings.cssSheetName = EVUI.Modules.Styles.Constants.DefaultStyleSheetName;
-    _settings.eventNamePrefix = EVUI.Modules.PopIns.Constants.Default_EventNamePrefix;
+    _settings.stepPrefix = EVUI.Modules.PopIns.Constants.Default_StepPrefix;
     _settings.managerName = EVUI.Modules.PopIns.Constants.Default_ManagerName;
     _settings.objectName = EVUI.Modules.PopIns.Constants.Default_ObjectName;
     _settings.makeOrExtendObject = makeOrExtendObject;

--- a/src/raw/Modules/PopIns.js
+++ b/src/raw/Modules/PopIns.js
@@ -507,7 +507,8 @@ EVUI.Modules.PopIns.PopInManager = function (services)
 
         var popInEventArgs = new EVUI.Modules.PopIns.PopInEventArgs(argsPackage, args);
         popInEventArgs.cancel = windowEventArgs.cancel;
-        popInEventArgs.key = windowEventArgs.key;
+        popInEventArgs.eventType = windowEventArgs.eventType;
+        popInEventArgs.eventName = windowEventArgs.eventName;
         popInEventArgs.pause = windowEventArgs.pause;
         popInEventArgs.resume = windowEventArgs.resume;
         popInEventArgs.stopPropagation = windowEventArgs.stopPropagation;
@@ -1105,20 +1106,24 @@ EVUI.Modules.PopIns.PopInEventArgs = function (argsPackage, currentArgs)
             enumerable: true
         });
 
-    /**String. The unique key current step in the EventStream.
+    /**String. The full name of the event.
     @type {String}*/
-    this.key = null;
+    this.eventName = null;
 
-    /**Function. Pauses the EventStream, preventing the next step from executing until resume is called.*/
+    /**String. The type of event being raised.
+    @type {String}*/
+    this.eventType = null;
+
+    /**Pauses the PopIn's action, preventing the next step from executing until resume is called.*/
     this.pause = function () { };
 
-    /**Function. Resumes the EventStream, allowing it to continue to the next step.*/
+    /**Resumes the PopIn's action, allowing it to continue to the next step.*/
     this.resume = function () { };
 
-    /**Function. Cancels the EventStream and aborts the execution of the PopIn operation.*/
+    /**Cancels the PopIn's action and aborts the execution of the operation.*/
     this.cancel = function () { }
 
-    /**Function. Stops the EventStream from calling any other event handlers with the same key.*/
+    /**Stops the PopIn from calling any other event handlers with the same eventType.*/
     this.stopPropagation = function () { };
 
     /**Object. The position of the PopIn that has been calculated in using the currentShowSettings.
@@ -1131,7 +1136,7 @@ EVUI.Modules.PopIns.PopInEventArgs = function (argsPackage, currentArgs)
             enumerable: true
         });
 
-    /**Object. The PaneHide/Show/Load/Unload Arguments being used for the operation.
+    /**Object. The PopInHide/Show/Load/Unload Arguments being used for the operation.
     @type {EVUI.Modules.PopIns.PopInShowArgs|EVUI.Modules.PopIns.PopInHideArgs|EVUI.Modules.PopIns.PopInLoadArgs|EVUI.Modules.PopIns.PopInUnloadArgs}*/
     this.currentActionArgs = null;
     Object.defineProperty(this, "currentActionArgs", {

--- a/src/raw/Modules/TreeView.js
+++ b/src/raw/Modules/TreeView.js
@@ -831,8 +831,10 @@ EVUI.Modules.TreeView.TreeViewController = function (services)
         opSession.eventStream.processInjectedEventArgs = function (eventStreamArgs)
         {
             var treeViewArgs = new EVUI.Modules.TreeView.TreeViewEventArgs(opSession.nodeEntry);
+            treeViewArgs.eventName = eventStreamArgs.name;
+            treeViewArgs.eventType = eventStreamArgs.key;
             treeViewArgs.cancel = function () { return eventStreamArgs.cancel(); };
-            treeViewArgs.key = eventStreamArgs.key;
+            treeViewArgs.eventType = eventStreamArgs.key;
             treeViewArgs.pause = function () { return eventStreamArgs.pause(); };
             treeViewArgs.resume = function () { return eventStreamArgs.resume(); };
             treeViewArgs.stopPropagation = function () { return eventStreamArgs.stopPropagation(); };
@@ -3846,7 +3848,7 @@ EVUI.Modules.TreeView.ExpandCollapseTreeViewNodeArgs = function ()
     @type {EVUI.Modules.TreeView.TreeViewNodeTransition}*/
     this.transition = null;
 
-    /**Object. In the event that the TreeViewNode is being expanded, these are the arugments that contorl how the TreeViewNode or its children will be built.
+    /**Object. In the event that the TreeViewNode is being expanded, these are the arguments that control how the TreeViewNode or its children will be built.
     @type {EVUI.Modules.TreeView.BuildTreeViewNodeArgs}*/
     this.buildArgs = null;
 
@@ -3855,7 +3857,7 @@ EVUI.Modules.TreeView.ExpandCollapseTreeViewNodeArgs = function ()
     this.context = {};
 };
 
-/**Object for containing the CSS details of the transition to apply to a TreeViewNode as it expands or collaposes.
+/**Object for containing the CSS details of the transition to apply to a TreeViewNode as it expands or collapses.
 @class*/
 EVUI.Modules.TreeView.TreeViewNodeTransition = function ()
 {
@@ -3867,12 +3869,12 @@ EVUI.Modules.TreeView.TreeViewNodeTransition = function ()
     @type {String}*/
     this.keyframes = null;
 
-    /**The duration (in milliseconds) of the transition so that the appropate events are only fired once the transition is complete.
+    /**The duration (in milliseconds) of the transition so that the appropriate events are only fired once the transition is complete.
     @type {Number}*/
     this.duration = 0;
 };
 
-/**Event arguements object for all TreeView and TreeViewNode events.
+/**Event arguments object for all TreeView and TreeViewNode events.
 @class*/
 EVUI.Modules.TreeView.TreeViewEventArgs = function (nodeEntry)
 {
@@ -3890,7 +3892,7 @@ EVUI.Modules.TreeView.TreeViewEventArgs = function (nodeEntry)
         enumerable: true
     });
 
-    /**Object. The TreeViewNode that is the subject of the evdent.
+    /**Object. The TreeViewNode that is the subject of the event.
     @type {EVUI.Modules.TreeView.TreeViewNode}*/
     this.node = null;
     Object.defineProperty(this, "node", {
@@ -3902,20 +3904,24 @@ EVUI.Modules.TreeView.TreeViewEventArgs = function (nodeEntry)
         enumerable: true
     });
 
-    /**String. The unique key current step in the EventStream.
+    /**String. The full name of the event.
     @type {String}*/
-    this.key = null;
+    this.eventName = null;
 
-    /**Pauses the EventStream, preventing the next step from executing until resume is called.*/
+    /**String. The type of event being raised.
+    @type {String}*/
+    this.eventType = null;
+
+    /**Pauses the TreeViewNode's action, preventing the next step from executing until resume is called.*/
     this.pause = function () { };
 
-    /**Resumes the EventStream, allowing it to continue to the next step.*/
+    /**Resumes the TreeViewNode's action, allowing it to continue to the next step.*/
     this.resume = function () { };
 
-    /**Cancels the EventStream and aborts the execution of the operation.*/
+    /**Cancels theTreeViewNode's action and aborts the execution of the operation.*/
     this.cancel = function () { }
 
-    /**Stops the EventStream from calling any other event handlers with the same name.*/
+    /**Stops the TreeViewNode from calling any other event handlers with the same eventType.*/
     this.stopPropagation = function () { };
 
     /**Object. Any state value to carry between events.


### PR DESCRIPTION
All event-driven components now follow the same pattern for event and job names, and all event-driven components now have the same set of standard properties on their event argument objects.