### PR TITLE
Pane move resize events

### DIFF
--- a/test/EventUITest/EventUITest.csproj
+++ b/test/EventUITest/EventUITest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/test/EventUITest/wwwroot/js/TestScript/Panes/paneMoveResize.js
+++ b/test/EventUITest/wwwroot/js/TestScript/Panes/paneMoveResize.js
@@ -2,16 +2,19 @@
 {
     var d = document.createElement("div");
     d.classList.add("testDialog");
+    d.style.height = "200px";
+    d.style.width = "200px";
+    d.style.background = "blue";
 
-    $evui.css({
-        selector: ".testDialog",
-        rules:
-        {
-            height: "400px",
-            width: "500px",
-            background: "red"
-        }
-    });
+    //$evui.css({
+    //    selector: ".testDialog",
+    //    rules:
+    //    {
+    //        height: "400px",
+    //        width: "500px",
+    //        background: "red"
+    //    }
+    //});
 
     d.setAttribute("evui-pane-drag-handle", "");
 
@@ -36,7 +39,15 @@
         onShow: function ()
         {
             console.log(this.myProp);
-        }
+        }, 
+        onMove: async function (args)
+        {
+            console.log("Moved", args.moveArgs);
+        },
+        onResize: async function (args)
+        {
+            console.log("Resized", args.resizeArgs);
+        },
     });
 
     $evui.panes.onInitialize = function ()

--- a/test/EventUITest/wwwroot/js/TestScript/Panes/paneMoveResize.js
+++ b/test/EventUITest/wwwroot/js/TestScript/Panes/paneMoveResize.js
@@ -25,8 +25,8 @@
         },
         resizeMoveSettings:
         {
-            canResizeBottom: false,
-            canResizeTop: false,
+            canResizeBottom: true,
+            canResizeTop: true,
             canDragMove: true
         },
         autoHideSettings:


### PR DESCRIPTION
This pull request includes several changes to the `EventUITest` project, focusing on updating the target framework, modifying the pane move and resize functionality, and enhancing the logging of pane actions.

### Changes to target framework:
* [`test/EventUITest/EventUITest.csproj`](diffhunk://#diff-371e0045fb18701de12f6ec945caf07893687e270a0c01bead829e7301443e56L4-R4): Updated the target framework from `net7.0` to `net9.0`.

### Modifications to pane move and resize functionality:
* `test/EventUITest/wwwroot/js/TestScript/Panes/paneMoveResize.js`: 
  * Updated the style of `testDialog` elements directly in JavaScript and commented out the previous CSS rule application.
  * Enabled resizing from the top and bottom by setting `canResizeTop` and `canResizeBottom` to `true`.
  * Added asynchronous logging for pane move and resize events to provide more detailed feedback during these actions.