### PR TITLE
Version 1 0 0 0 1

### DIFF
--- a/src/raw/Modules/Binding.js
+++ b/src/raw/Modules/Binding.js
@@ -7801,7 +7801,7 @@ EVUI.Modules.Binding.Binding = function (handle)
         }
 
         EVUI.Modules.Core.Utils.shallowExtend(this, template, ["templateName"]);
-        _handle.templateName = templateName;
+        _handle.templateName = template.templateName;
 
         return true;
     };

--- a/src/raw/Modules/Core.js
+++ b/src/raw/Modules/Core.js
@@ -1045,7 +1045,7 @@ EVUI.Modules.Core.DeepExtenderOptions = function ()
     @type {EVUI.Modules.Core.Constants.Fn_DeepExtendPropertyFilter|String[]}*/
     this.filter = null;
 
-    /**An optional filter function used to filter out properties from the source to extend onto the target, return false to not extend the property onto the target object. Or an array of property names to not extend onto the target object.
+    /**An optional filter function used to filter out properties to not recurse deeper into the object hierarchy when found. Or an array of property names to not recurse into when found.
     @type {EVUI.Modules.Core.Constants.Fn_DeepExtendPropertyFilter}*/
     this.recursionFilter = null;
 };

--- a/src/raw/Modules/Panes.js
+++ b/src/raw/Modules/Panes.js
@@ -7205,8 +7205,8 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerServices)
             curZIndex = EVUI.Modules.Panes.Constants.GlobalZIndex;
             var selector = "." + paneEntry.link.paneCSSName + "." + EVUI.Modules.Panes.Constants.CSS_Position;
 
-            EVUI.Modules.Styles.Manager.ensureSheet(EVUI.Modules.Styles.Constants.DefaultStyleSheetName, { lock: true });
-            EVUI.Modules.Styles.Manager.setRules(EVUI.Modules.Styles.Constants.DefaultStyleSheetName, selector, { zIndex: curZIndex });
+            _settings.stylesheetManager.ensureSheet(EVUI.Modules.Styles.Constants.DefaultStyleSheetName, { lock: true });
+            _settings.stylesheetManager.setRules(EVUI.Modules.Styles.Constants.DefaultStyleSheetName, selector, { zIndex: curZIndex });
         });
 
         handler.attach();

--- a/src/raw/Modules/Panes.js
+++ b/src/raw/Modules/Panes.js
@@ -7956,7 +7956,7 @@ EVUI.Modules.Panes.Pane = function (entry)
     this.load = function (loadArgs, callback)
     {
         if (_entry.link.removed === true) throw Error("Pane was removed from its PaneManager and cannot perform operations.");
-        return options.link.manager.loadPane(_entry.paneId, loadArgs, callback);
+        return _entry.link.manager.loadPane(_entry.paneId, loadArgs, callback);
     };
 
     /**Awaitable. Asynchronously loads a Pane. 
@@ -7966,7 +7966,7 @@ EVUI.Modules.Panes.Pane = function (entry)
     this.loadAsync = function (loadArgs)
     {
         if (_entry.link.removed === true) throw Error("Pane was removed from its PaneManager and cannot perform operations.");
-        return options.link.manager.loadPaneAsync(_entry.paneId, loadArgs);
+        return _entry.link.manager.loadPaneAsync(_entry.paneId, loadArgs);
     }
 
     /**Asynchronously unloads a Pane, which disconnects the Pane's element and removes it from the DOM if it was loaded remotely. Provides a callback that is called after the operation has completed successfully or otherwise.
@@ -7975,7 +7975,7 @@ EVUI.Modules.Panes.Pane = function (entry)
     this.unload = function (unloadArgs, callback)
     {
         if (_entry.link.removed === true) throw Error("Pane was removed from its PaneManager and cannot perform operations.");
-        return options.link.manager.unloadPane(_entry.paneId, unloadArgs, callback);
+        return _entry.link.manager.unloadPane(_entry.paneId, unloadArgs, callback);
     };
 
     /**Awaitable. Asynchronously unloads a Pane, which disconnects the Pane's element and removes it from the DOM if it was loaded remotely.
@@ -7984,7 +7984,7 @@ EVUI.Modules.Panes.Pane = function (entry)
     this.unloadAsync = function (unloadArgs)
     {
         if (_entry.link.removed === true) throw Error("Pane was removed from its PaneManager and cannot perform operations.");
-        return options.link.manager.unloadPaneAsync(_entry.paneId, unloadArgs);
+        return _entry.link.manager.unloadPaneAsync(_entry.paneId, unloadArgs);
     };
 
     /**Asynchronously moves a currently visible pane to a new location.
@@ -7993,7 +7993,7 @@ EVUI.Modules.Panes.Pane = function (entry)
     this.movePane = function (paneMoveArgs, callback)
     {
         if (_entry.link.removed === true) throw Error("Pane was removed from its PaneManager and cannot perform operations.");
-        return options.link.manager.movePane(_entry.paneId, paneMoveArgs, callback);
+        return _entry.link.manager.movePane(_entry.paneId, paneMoveArgs, callback);
     };
 
     /**Awaitable. Asynchronously moves a currently visible pane to a new location.
@@ -8002,7 +8002,7 @@ EVUI.Modules.Panes.Pane = function (entry)
     this.movePaneAsync = function (paneMoveArgs)
     {
         if (_entry.link.removed === true) throw Error("Pane was removed from its PaneManager and cannot perform operations.");
-        return options.link.manager.movePaneAsync(_entry.paneId, paneMoveArgs);
+        return _entry.link.manager.movePaneAsync(_entry.paneId, paneMoveArgs);
     };
 
     /**Asynchronously resizes a currently visible pane.
@@ -8011,7 +8011,7 @@ EVUI.Modules.Panes.Pane = function (entry)
     this.resizePane = function (paneResizeArgs, callback)
     {
         if (_entry.link.removed === true) throw Error("Pane was removed from its PaneManager and cannot perform operations.");
-        return options.link.manager.resizePane(_entry.paneId, paneResizeArgs, callback);
+        return _entry.link.manager.resizePane(_entry.paneId, paneResizeArgs, callback);
     };
 
     /**Awaitable. Asynchronously resizes a currently visible pane.
@@ -8019,7 +8019,7 @@ EVUI.Modules.Panes.Pane = function (entry)
     this.resizePaneAsync = function (paneResizeArgs)
     {
         if (_entry.link.removed === true) throw Error("Pane was removed from its PaneManager and cannot perform operations.");
-        return options.link.manager.resizePaneAsync(_entry.paneId, paneResizeArgs);
+        return _entry.link.manager.resizePaneAsync(_entry.paneId, paneResizeArgs);
     };
 
     /**Calculates and gets the absolute position of the Pane.

--- a/src/raw/Modules/Panes.js
+++ b/src/raw/Modules/Panes.js
@@ -353,6 +353,10 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerServices)
         /**String. The rules of the style tag that were inlined on the root element on the Pane.
         @type {String}*/
         this.inlinedStyle = null;
+
+        /**String. The name of the template that the pane's properties were based off of.
+        @type {String}*/
+        this.template = null;
     };
 
 
@@ -2673,6 +2677,7 @@ EVUI.Modules.Panes.PaneManager = function (paneManagerServices)
         //found an existing pane, erxtend the parameters onto it, return it, and then we're done.
         if (existing != null)
         {
+            if (EVUI.Modules.Core.Utils.stringIsNullOrWhitespace(yoloPane.template) === false) existing.link.template = yoloPane.template;
             extendPane(existing.link.pane, yoloPane); //extend the properties of the pane with the yolo object passed in by the user
             return existing;
         }

--- a/test/EventUITest/wwwroot/js/TestScript/Panes/paneMoveResize.js
+++ b/test/EventUITest/wwwroot/js/TestScript/Panes/paneMoveResize.js
@@ -30,7 +30,8 @@
         {
             canResizeBottom: true,
             canResizeTop: true,
-            canDragMove: true
+            canDragMove: true,
+            retainResizedDimensions: true
         },
         autoHideSettings:
         {

--- a/test/test_src/modules/panes/panes-add.js
+++ b/test/test_src/modules/panes/panes-add.js
@@ -1,0 +1,69 @@
+await $evui.testAsync({
+    testArgs: "Test - addPane",
+    test: function (args)
+    {
+        var paneID = $evui.guid();
+        var pane = $evui.addPane({
+            id: paneID
+        });
+
+        $evui.assert(pane).is($evui.getPane(paneID));
+    }
+});
+
+await $evui.testAsync({
+    testArgs: "Test - removePane",
+    test: function (args)
+    {
+        var paneID = $evui.guid();
+        var pane = $evui.addPane({
+            id: paneID
+        });
+
+        $evui.assert(pane).is($evui.getPane(paneID));
+        $evui.panes.removePane(paneID);
+
+        $evui.assert($evui.getPane(paneID)).is(null);
+    }
+});
+
+await $evui.testAsync({
+    name: "Test - addPane - custom property",
+    testArgs: PaneTest.customPropertyValues,
+    test: function (hostArgs, customValue)
+    {
+        var paneID = $evui.guid();
+        var pane = $evui.addPane({
+            id: paneID,
+            custom: customValue
+        });
+
+        var processedPane = $evui.getPane(paneID);
+        $evui.assert(processedPane.custom).is(customValue);
+    }
+});
+
+await $evui.testAsync({
+    name: "Test - addPane - nested custom properties",
+    testArgs: PaneTest.nestedCustomPropertyValues,
+    test: function (hostArgs, path, valueName, customValues)
+    {
+        hostArgs.outputWriter.logDebug(path);
+        var fullPath = $evui.isStringValid(valueName) === true ? `${path}.${valueName}` : path;
+        var customValueGenerator = customValues();
+
+        for (var val of customValueGenerator)
+        {
+            let paneID = $evui.guid();
+            let pane = {
+                id: paneID
+            };
+
+            hostArgs.outputWriter.logDebug("Adding property:" + JSON.stringify(val));
+            $evui.set(fullPath, pane, val, true);
+
+            var realPane = $evui.addPane(pane);
+            $evui.assert(val).is($evui.get(fullPath, realPane));
+        }
+    }
+});

--- a/test/test_src/modules/panes/panes.common.js
+++ b/test/test_src/modules/panes/panes.common.js
@@ -1,0 +1,34 @@
+const PaneTest = {};
+
+PaneTest.customPropertyValues = function* ()
+{
+    yield 123;
+    yield { a: 1 };
+    yield [1, 2, 3];
+    yield { a: 1, b: { c: 2 } };
+    yield function () { };
+    yield Symbol("abc");
+};
+
+PaneTest.nestedCustomPropertyValues = function* ()
+{
+    yield ["showSettings", "custom", PaneTest.customPropertyValues];
+    yield ["showSettings.absolutePosition", "custom", PaneTest.customPropertyValues];
+    yield ["showSettings.relativePosition", "custom", PaneTest.customPropertyValues];
+    yield ["showSettings.anchors", "custom", PaneTest.customPropertyValues];
+    yield ["showSettings.documentFlow", "custom", PaneTest.customPropertyValues];
+    yield ["showSettings.clipSettings", "custom", PaneTest.customPropertyValues];
+    yield ["showSettings.clipSettings.clipBounds", "custom", PaneTest.customPropertyValues];
+    yield ["showSettings.showTransition", "custom", PaneTest.customPropertyValues];
+    yield ["showSettings.hideTransition", "custom", PaneTest.customPropertyValues];
+    yield ["showSettings.backdropSettings", "custom", PaneTest.customPropertyValues];
+    yield ["showSettings.backdropSettings.backdropShowTransition", "custom", PaneTest.customPropertyValues];
+    yield ["showSettings.backdropSettings.backdropHideTransition", "custom", PaneTest.customPropertyValues];
+    yield ["loadSettings", "custom", PaneTest.customPropertyValues];
+    yield ["loadSettings.httpLoadArgs", "custom", PaneTest.customPropertyValues];
+    yield ["loadSettings.placeholderLoadArgs", "custom", PaneTest.customPropertyValues];
+    yield ["resizeMoveSettings", "custom", PaneTest.customPropertyValues];
+    yield ["resizeMoveSettings.resizeTransition", "custom", PaneTest.customPropertyValues];
+    yield ["resizeMoveSettings.moveTransition", "custom", PaneTest.customPropertyValues];
+    yield ["autoHideSettings", "custom", PaneTest.customPropertyValues];
+}


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the `PaneManager` class in `src/raw/Modules/Panes.js`, along with minor updates in other files. The main changes include adding support for reusing the last operation arguments for pane actions, improving error handling, and adding new properties to track pane state. Additionally, there are updates to improve clarity in comments and simplify code logic.

### Enhancements to `PaneManager` functionality:
* Added support for reusing the last operation arguments (`PaneShowArgs`, `PaneHideArgs`, `PaneLoadArgs`, `PaneUnloadArgs`, `PaneMoveArgs`) by passing `true` to relevant methods (`showPane`, `hidePane`, `loadPane`, `unloadPane`, `movePane`). This simplifies re-executing the last operation. [[1]](diffhunk://#diff-18d5b6619a27a66ae06f18bff0e6dc537fef584afbe9f54a4853d05b7bf07193R1110-R1115) [[2]](diffhunk://#diff-18d5b6619a27a66ae06f18bff0e6dc537fef584afbe9f54a4853d05b7bf07193R1191-R1196) [[3]](diffhunk://#diff-18d5b6619a27a66ae06f18bff0e6dc537fef584afbe9f54a4853d05b7bf07193R1276-R1281) [[4]](diffhunk://#diff-18d5b6619a27a66ae06f18bff0e6dc537fef584afbe9f54a4853d05b7bf07193R1355-R1360) [[5]](diffhunk://#diff-18d5b6619a27a66ae06f18bff0e6dc537fef584afbe9f54a4853d05b7bf07193R1414-R1429)

* Improved error handling in `movePane` to ensure valid `top` or `left` properties are provided for the move operation. If invalid, an error is thrown with a clear message.

### New properties for pane state tracking:
* Added properties to track the last resolved arguments for various operations (`lastResolvedHideArgs`, `lastResolvedUnloadArgs`, `lastResolvedMoveArgs`, `lastResolvedResizeArgs`) and pane-specific properties like `resizedHeight`, `resizedWidth`, and `template`. These additions enhance the ability to manage and debug pane state. [[1]](diffhunk://#diff-18d5b6619a27a66ae06f18bff0e6dc537fef584afbe9f54a4853d05b7bf07193R329-R344) [[2]](diffhunk://#diff-18d5b6619a27a66ae06f18bff0e6dc537fef584afbe9f54a4853d05b7bf07193R372-R385)

### Code simplification and improvements:
* Replaced `paneID.id` and `getPaneEntry` with `makeOrGetPane` for consistency and reduced redundancy when fetching or creating pane entries.

### Updates to comments and documentation:
* Updated comments to clarify the behavior of filter functions and recursion filters in `DeepExtenderOptions`.

### Minor fixes:
* Fixed a bug where `_handle.templateName` was incorrectly assigned; now uses `template.templateName`.